### PR TITLE
fix: core blocks setup

### DIFF
--- a/packages/wordpress/php/RenderBlock/Setup.php
+++ b/packages/wordpress/php/RenderBlock/Setup.php
@@ -115,6 +115,9 @@ class Setup {
 			case 'core':
 				$this->block_dir_path = sprintf( 'wordpress/%s', $parsedName[1] );
 				break;
+			case 'woocommerce':
+				$this->block_dir_path = sprintf( 'woocommerce/%s', $parsedName[1] );
+				break;
 			// TODO: Implements other blocks in this here ...
 		}
 	}


### PR DESCRIPTION
  ## What?
  Setup core blocks directory path.
  
  ## Why?
  In setup core blocks process we should use prefix of block name to set block directory, because not accessible blocks config in server side.