### PR TITLE
fix: explode(): Argument #2 () must be of type string, array given

### DIFF
--- a/packages/blocks/core/php/woocommerce/checkout-billing-address-block/block.php
+++ b/packages/blocks/core/php/woocommerce/checkout-billing-address-block/block.php
@@ -13,13 +13,11 @@ return array_merge(
 		'selectors' => array_merge(
 			$args['selectors'] ?? [],
 			[
-				'innerBlocks' => [
-					'core/heading'     => [
-						'root' => '.wc-block-components-checkout-step__heading .wc-block-components-title',
-					],
-					'core/description' => [
-						'root' => '.wc-block-components-checkout-step__description',
-					],
+				'blockera/core/heading'     => [
+					'root' => '.wc-block-components-checkout-step__heading .wc-block-components-title',
+				],
+				'blockera/core/description' => [
+					'root' => '.wc-block-components-checkout-step__description',
 				],
 			]
 		),

--- a/packages/blocks/core/php/woocommerce/checkout-contact-information-block/block.php
+++ b/packages/blocks/core/php/woocommerce/checkout-contact-information-block/block.php
@@ -13,13 +13,11 @@ return array_merge(
 		'selectors' => array_merge(
 			$args['selectors'] ?? [],
 			[
-				'innerBlocks' => [
-					'core/heading'     => [
-						'root' => '.wc-block-components-checkout-step__heading .wc-block-components-title',
-					],
-					'core/description' => [
-						'root' => '.wc-block-components-checkout-step__description',
-					],
+				'blockera/core/heading'     => [
+					'root' => '.wc-block-components-checkout-step__heading .wc-block-components-title',
+				],
+				'blockera/core/description' => [
+					'root' => '.wc-block-components-checkout-step__description',
 				],
 			]
 		),

--- a/packages/blocks/core/php/woocommerce/checkout-payment-block/block.php
+++ b/packages/blocks/core/php/woocommerce/checkout-payment-block/block.php
@@ -13,13 +13,11 @@ return array_merge(
 		'selectors' => array_merge(
 			$args['selectors'] ?? [],
 			[
-				'innerBlocks' => [
-					'core/heading'     => [
-						'root' => '.wc-block-components-checkout-step__heading .wc-block-components-title',
-					],
-					'core/description' => [
-						'root' => '.wc-block-components-checkout-step__description',
-					],
+				'blockera/core/heading'     => [
+					'root' => '.wc-block-components-checkout-step__heading .wc-block-components-title',
+				],
+				'blockera/core/description' => [
+					'root' => '.wc-block-components-checkout-step__description',
 				],
 			]
 		),

--- a/packages/blocks/core/php/woocommerce/checkout-shipping-address-block/block.php
+++ b/packages/blocks/core/php/woocommerce/checkout-shipping-address-block/block.php
@@ -13,13 +13,11 @@ return array_merge(
 		'selectors' => array_merge(
 			$args['selectors'] ?? [],
 			[
-				'innerBlocks' => [
-					'core/heading'     => [
-						'root' => '.wc-block-components-checkout-step__heading .wc-block-components-title',
-					],
-					'core/description' => [
-						'root' => '.wc-block-components-checkout-step__description',
-					],
+				'blockera/core/heading'     => [
+					'root' => '.wc-block-components-checkout-step__heading .wc-block-components-title',
+				],
+				'blockera/core/description' => [
+					'root' => '.wc-block-components-checkout-step__description',
 				],
 			]
 		),

--- a/packages/blocks/core/php/woocommerce/checkout-shipping-methods-block/block.php
+++ b/packages/blocks/core/php/woocommerce/checkout-shipping-methods-block/block.php
@@ -13,13 +13,11 @@ return array_merge(
 		'selectors' => array_merge(
 			$args['selectors'] ?? [],
 			[
-				'innerBlocks' => [
-					'core/heading'     => [
-						'root' => '.wc-block-components-checkout-step__heading .wc-block-components-title',
-					],
-					'core/description' => [
-						'root' => '.wc-block-components-checkout-step__description',
-					],
+				'blockera/core/heading'     => [
+					'root' => '.wc-block-components-checkout-step__heading .wc-block-components-title',
+				],
+				'blockera/core/description' => [
+					'root' => '.wc-block-components-checkout-step__description',
 				],
 			]
 		),

--- a/packages/blocks/core/php/woocommerce/order-confirmation-summary/block.php
+++ b/packages/blocks/core/php/woocommerce/order-confirmation-summary/block.php
@@ -13,16 +13,14 @@ return array_merge(
 		'selectors' => array_merge(
 			$args['selectors'] ?? [],
 			[
-				'innerBlocks' => [
-					'elements/item-container' => [
-						'root' => '.wc-block-order-confirmation-summary-list-item',
-					],
-					'elements/item-title'     => [
-						'root' => '.wc-block-order-confirmation-summary-list-item__key',
-					],
-					'elements/item-value'     => [
-						'root' => 'wc-block-order-confirmation-summary-list-item__value',
-					],
+				'blockera/elements/item-container' => [
+					'root' => '.wc-block-order-confirmation-summary-list-item',
+				],
+				'blockera/elements/item-title'     => [
+					'root' => '.wc-block-order-confirmation-summary-list-item__key',
+				],
+				'blockera/elements/item-value'     => [
+					'root' => 'wc-block-order-confirmation-summary-list-item__value',
 				],
 			]
 		),

--- a/packages/blocks/core/php/woocommerce/product-image/block.php
+++ b/packages/blocks/core/php/woocommerce/product-image/block.php
@@ -13,10 +13,8 @@ return array_merge(
 		'selectors' => array_merge(
 			$args['selectors'] ?? [],
 			[
-				'innerBlocks' => [
-					'elements/sale-badge' => [
-						'root' => '.wc-block-components-product-sale-badge',
-					],
+				'blockera/elements/sale-badge' => [
+					'root' => '.wc-block-components-product-sale-badge',
 				],
 			]
 		),

--- a/packages/blocks/core/php/woocommerce/product-price/block.php
+++ b/packages/blocks/core/php/woocommerce/product-price/block.php
@@ -13,16 +13,14 @@ return array_merge(
 		'selectors' => array_merge(
 			$args['selectors'] ?? [],
 			[
-				'innerBlocks' => [
-					'elements/currency-symbol'     => [
-						'root' => '.woocommerce-Price-currencySymbol',
-					],
-					'elements/sale-discount-price' => [
-						'root' => 'del .woocommerce-Price-amount',
-					],
-					'elements/sale-normal-price'   => [
-						'root' => 'ins .woocommerce-Price-amount',
-					],
+				'blockera/elements/currency-symbol'     => [
+					'root' => '.woocommerce-Price-currencySymbol',
+				],
+				'blockera/elements/sale-discount-price' => [
+					'root' => 'del .woocommerce-Price-amount',
+				],
+				'blockera/elements/sale-normal-price'   => [
+					'root' => 'ins .woocommerce-Price-amount',
 				],
 			]
 		),

--- a/packages/blocks/core/php/woocommerce/product-sku/block.php
+++ b/packages/blocks/core/php/woocommerce/product-sku/block.php
@@ -13,10 +13,8 @@ return array_merge(
 		'selectors' => array_merge(
 			$args['selectors'] ?? [],
 			[
-				'innerBlocks' => [
-					'elements/sku' => [
-						'root' => '.sku',
-					],
+				'blockera/elements/sku' => [
+					'root' => '.sku',
 				],
 			]
 		),

--- a/packages/blocks/core/php/woocommerce/product-template/block.php
+++ b/packages/blocks/core/php/woocommerce/product-template/block.php
@@ -21,9 +21,7 @@ return array_merge(
 		),
 		'selectors'  => array_merge(
 			$args['selectors'] ?? [],
-			[
-				'innerBlocks' => blockera_load( 'inners.link', dirname( __DIR__ ) ),
-			]
+			blockera_load( 'wordpress.inners.link', dirname( __DIR__, 2 ) )
 		),
 	]
 );

--- a/packages/blocks/core/php/wordpress/buttons/block.php
+++ b/packages/blocks/core/php/wordpress/buttons/block.php
@@ -21,9 +21,7 @@ return array_merge(
 		),
 		'selectors'  => array_merge(
 			$args['selectors'] ?? [],
-			[
-				'innerBlocks' => blockera_load( 'inners.button', dirname( __DIR__ ) ),
-			]
+			blockera_load( 'inners.button', dirname( __DIR__ ) )
 		),
 	]
 );

--- a/packages/blocks/core/php/wordpress/categories/block.php
+++ b/packages/blocks/core/php/wordpress/categories/block.php
@@ -13,13 +13,11 @@ return array_merge(
 		'selectors' => array_merge(
 			$args['selectors'] ?? [],
 			[
-				'innerBlocks' => [
-					'elements/term-item' => [
-						'root' => 'li.cat-item > a',
-					],
-					'elements/list-item' => [
-						'root' => 'li.cat-item',
-					],
+				'blockera/elements/term-item' => [
+					'root' => 'li.cat-item > a',
+				],
+				'blockera/elements/list-item' => [
+					'root' => 'li.cat-item',
 				],
 			]
 		),

--- a/packages/blocks/core/php/wordpress/column/block.php
+++ b/packages/blocks/core/php/wordpress/column/block.php
@@ -20,14 +20,12 @@ return array_merge(
 		),
 		'selectors' => array_merge(
 			$args['selectors'] ?? [],
-			[
-				'innerBlocks' => array_merge(
-					blockera_load( 'inners.link', dirname( __DIR__ ) ),
-					blockera_load( 'inners.button', dirname( __DIR__ ) ),
-					blockera_load( 'inners.headings', dirname( __DIR__ ) ),
-					blockera_load( 'inners.paragraph', dirname( __DIR__ ) ),
-				),
-			]
+			(array) array_merge(
+				blockera_load( 'inners.link', dirname( __DIR__ ) ),
+				blockera_load( 'inners.button', dirname( __DIR__ ) ),
+				blockera_load( 'inners.headings', dirname( __DIR__ ) ),
+				blockera_load( 'inners.paragraph', dirname( __DIR__ ) ),
+			)
 		),
 	]
 );

--- a/packages/blocks/core/php/wordpress/columns/block.php
+++ b/packages/blocks/core/php/wordpress/columns/block.php
@@ -21,14 +21,12 @@ return array_merge(
 		),
 		'selectors'  => array_merge(
 			$args['selectors'] ?? [],
-			[
-				'innerBlocks' => array_merge(
-					blockera_load( 'inners.link', dirname( __DIR__ ) ),
-					blockera_load( 'inners.button', dirname( __DIR__ ) ),
-					blockera_load( 'inners.headings', dirname( __DIR__ ) ),
-					blockera_load( 'inners.paragraph', dirname( __DIR__ ) ),
-				),
-			]
+			(array) array_merge(
+				blockera_load( 'inners.link', dirname( __DIR__ ) ),
+				blockera_load( 'inners.button', dirname( __DIR__ ) ),
+				blockera_load( 'inners.headings', dirname( __DIR__ ) ),
+				blockera_load( 'inners.paragraph', dirname( __DIR__ ) ),
+			)
 		),
 	]
 );

--- a/packages/blocks/core/php/wordpress/comment-author-name/block.php
+++ b/packages/blocks/core/php/wordpress/comment-author-name/block.php
@@ -12,9 +12,7 @@ return array_merge(
 	[
 		'selectors' => array_merge(
 			$args['selectors'] ?? [],
-			[
-				'innerBlocks' => blockera_load( 'inners.link', dirname( __DIR__ ) ),
-			]
+			blockera_load( 'inners.link', dirname( __DIR__ ) )
 		),
 	]
 );

--- a/packages/blocks/core/php/wordpress/comment-content/block.php
+++ b/packages/blocks/core/php/wordpress/comment-content/block.php
@@ -12,9 +12,7 @@ return array_merge(
 	[
 		'selectors' => array_merge(
 			$args['selectors'] ?? [],
-			[
-				'innerBlocks' => blockera_load( 'inners.link', dirname( __DIR__ ) ),
-			]
+			blockera_load( 'inners.link', dirname( __DIR__ ) )
 		),
 	]
 );

--- a/packages/blocks/core/php/wordpress/comment-date/block.php
+++ b/packages/blocks/core/php/wordpress/comment-date/block.php
@@ -12,9 +12,7 @@ return array_merge(
 	[
 		'selectors' => array_merge(
 			$args['selectors'] ?? [],
-			[
-				'innerBlocks' => blockera_load( 'inners.link', dirname( __DIR__ ) ),
-			]
+			blockera_load( 'inners.link', dirname( __DIR__ ) ),
 		),
 	]
 );

--- a/packages/blocks/core/php/wordpress/comment-edit-link/block.php
+++ b/packages/blocks/core/php/wordpress/comment-edit-link/block.php
@@ -12,9 +12,7 @@ return array_merge(
 	[
 		'selectors' => array_merge(
 			$args['selectors'] ?? [],
-			[
-				'innerBlocks' => blockera_load( 'inners.link', dirname( __DIR__ ) ),
-			]
+			blockera_load( 'inners.link', dirname( __DIR__ ) ),
 		),
 	]
 );

--- a/packages/blocks/core/php/wordpress/comment-reply-link/block.php
+++ b/packages/blocks/core/php/wordpress/comment-reply-link/block.php
@@ -12,9 +12,7 @@ return array_merge(
 	[
 		'selectors' => array_merge(
 			$args['selectors'] ?? [],
-			[
-				'innerBlocks' => blockera_load( 'inners.link', dirname( __DIR__ ) ),
-			]
+			blockera_load( 'inners.link', dirname( __DIR__ ) ),
 		),
 	]
 );

--- a/packages/blocks/core/php/wordpress/comments-pagination-next/block.php
+++ b/packages/blocks/core/php/wordpress/comments-pagination-next/block.php
@@ -13,10 +13,8 @@ return array_merge(
 		'selectors' => array_merge(
 			$args['selectors'] ?? [],
 			[
-				'innerBlocks' => [
-					'elements/arrow' => [
-						'root' => '.wp-block-comments-pagination-next-arrow',
-					],
+				'blockera/elements/arrow' => [
+					'root' => '.wp-block-comments-pagination-next-arrow',
 				],
 			]
 		),

--- a/packages/blocks/core/php/wordpress/comments-pagination-numbers/block.php
+++ b/packages/blocks/core/php/wordpress/comments-pagination-numbers/block.php
@@ -12,9 +12,7 @@ return array_merge(
 	[
 		'selectors' => array_merge(
 			$args['selectors'] ?? [],
-			[
-				'innerBlocks' => blockera_load( 'inners.numbers', dirname( __DIR__ ) ),
-			]
+			blockera_load( 'inners.numbers', dirname( __DIR__ ) )
 		),
 	]
 );

--- a/packages/blocks/core/php/wordpress/comments-pagination-previous/block.php
+++ b/packages/blocks/core/php/wordpress/comments-pagination-previous/block.php
@@ -13,10 +13,8 @@ return array_merge(
 		'selectors' => array_merge(
 			$args['selectors'] ?? [],
 			[
-				'innerBlocks' => [
-					'elements/arrow' => [
-						'root' => '.wp-block-comments-pagination-previous-arrow',
-					],
+				'blockera/elements/arrow' => [
+					'root' => '.wp-block-comments-pagination-previous-arrow',
 				],
 			]
 		),

--- a/packages/blocks/core/php/wordpress/comments-pagination/block.php
+++ b/packages/blocks/core/php/wordpress/comments-pagination/block.php
@@ -21,9 +21,7 @@ return array_merge(
 		),
 		'selectors'  => array_merge(
 			$args['selectors'] ?? [],
-			[
-				'innerBlocks' => blockera_load( 'inners.link', dirname( __DIR__ ) ),
-			]
+			blockera_load( 'inners.link', dirname( __DIR__ ) ),
 		),
 	]
 );

--- a/packages/blocks/core/php/wordpress/comments/block.php
+++ b/packages/blocks/core/php/wordpress/comments/block.php
@@ -12,13 +12,11 @@ return array_merge(
 	[
 		'selectors' => array_merge(
 			$args['selectors'] ?? [],
-			[
-				'innerBlocks' => array_merge(
-					blockera_load( 'inners.link', dirname( __DIR__ ) ),
-					blockera_load( 'inners.button', dirname( __DIR__ ) ),
-					blockera_load( 'inners.headings', dirname( __DIR__ ) ),
-				),
-			]
+			(array) array_merge(
+				blockera_load( 'inners.link', dirname( __DIR__ ) ),
+				blockera_load( 'inners.button', dirname( __DIR__ ) ),
+				blockera_load( 'inners.headings', dirname( __DIR__ ) ),
+			)
 		),
 	]
 );

--- a/packages/blocks/core/php/wordpress/cover/block.php
+++ b/packages/blocks/core/php/wordpress/cover/block.php
@@ -20,13 +20,11 @@ return array_merge(
 		),
 		'selectors' => array_merge(
 			$args['selectors'] ?? [],
-			[
-				'innerBlocks' => array_merge(
-					blockera_load( 'inners.button', dirname( __DIR__ ) ),
-					blockera_load( 'inners.headings', dirname( __DIR__ ) ),
-					blockera_load( 'inners.paragraph', dirname( __DIR__ ) ),
-				),
-			]
+			(array) array_merge(
+				blockera_load( 'inners.button', dirname( __DIR__ ) ),
+				blockera_load( 'inners.headings', dirname( __DIR__ ) ),
+				blockera_load( 'inners.paragraph', dirname( __DIR__ ) ),
+			)
 		),
 	]
 );

--- a/packages/blocks/core/php/wordpress/details/block.php
+++ b/packages/blocks/core/php/wordpress/details/block.php
@@ -20,12 +20,10 @@ return array_merge(
 		),
 		'selectors' => array_merge(
 			$args['selectors'] ?? [],
-			[
-				'innerBlocks' => array_merge(
-					blockera_load( 'inners.link', dirname( __DIR__ ) ),
-					blockera_load( 'inners.paragraph', dirname( __DIR__ ) ),
-				),
-			]
+			(array) array_merge(
+				blockera_load( 'inners.link', dirname( __DIR__ ) ),
+				blockera_load( 'inners.paragraph', dirname( __DIR__ ) ),
+			)
 		),
 	]
 );

--- a/packages/blocks/core/php/wordpress/file/block.php
+++ b/packages/blocks/core/php/wordpress/file/block.php
@@ -12,12 +12,10 @@ return array_merge(
 	[
 		'selectors' => array_merge(
 			$args['selectors'] ?? [],
-			[
-				'innerBlocks' => array_merge(
-					blockera_load( 'inners.link', dirname( __DIR__ ) ),
-					blockera_load( 'inners.button', dirname( __DIR__ ) ),
-				),
-			]
+			(array) array_merge(
+				blockera_load( 'inners.link', dirname( __DIR__ ) ),
+				blockera_load( 'inners.button', dirname( __DIR__ ) ),
+			)
 		),
 	]
 );

--- a/packages/blocks/core/php/wordpress/footnotes/block.php
+++ b/packages/blocks/core/php/wordpress/footnotes/block.php
@@ -12,9 +12,7 @@ return array_merge(
 	[
 		'selectors' => array_merge(
 			$args['selectors'] ?? [],
-			[
-				'innerBlocks' => blockera_load( 'inners.link', dirname( __DIR__ ) ),
-			]
+			blockera_load( 'inners.link', dirname( __DIR__ ) ),
 		),
 	]
 );

--- a/packages/blocks/core/php/wordpress/gallery/block.php
+++ b/packages/blocks/core/php/wordpress/gallery/block.php
@@ -22,16 +22,14 @@ return array_merge(
 		'selectors'  => array_merge(
 			$args['selectors'] ?? [],
 			[
-				'innerBlocks' => [
-					'core/image'               => [
-						'root' => '.wp-block-image img',
-					],
-					'elements/gallery-caption' => [
-						'root' => '> figcaption',
-					],
-					'elements/image-caption'   => [
-						'root' => '.wp-block-image figcaption',
-					],
+				'blockera/core/image'               => [
+					'root' => '.wp-block-image img',
+				],
+				'blockera/elements/gallery-caption' => [
+					'root' => '> figcaption',
+				],
+				'blockera/elements/image-caption'   => [
+					'root' => '.wp-block-image figcaption',
 				],
 			]
 		),

--- a/packages/blocks/core/php/wordpress/group/block.php
+++ b/packages/blocks/core/php/wordpress/group/block.php
@@ -20,14 +20,12 @@ return array_merge(
 		),
 		'selectors' => array_merge(
 			$args['selectors'] ?? [],
-			[
-				'innerBlocks' => array_merge(
-					blockera_load( 'inners.link', dirname( __DIR__ ) ),
-					blockera_load( 'inners.button', dirname( __DIR__ ) ),
-					blockera_load( 'inners.headings', dirname( __DIR__ ) ),
-					blockera_load( 'inners.paragraph', dirname( __DIR__ ) ),
-				),
-			]
+			(array) array_merge(
+				blockera_load( 'inners.link', dirname( __DIR__ ) ),
+				blockera_load( 'inners.button', dirname( __DIR__ ) ),
+				blockera_load( 'inners.headings', dirname( __DIR__ ) ),
+				blockera_load( 'inners.paragraph', dirname( __DIR__ ) ),
+			)
 		),
 	]
 );

--- a/packages/blocks/core/php/wordpress/heading/block.php
+++ b/packages/blocks/core/php/wordpress/heading/block.php
@@ -12,9 +12,7 @@ return array_merge(
 	[
 		'selectors' => array_merge(
 			$args['selectors'] ?? [],
-			[
-				'innerBlocks' => blockera_load( 'inners.link', dirname( __DIR__ ) ),
-			]
+			blockera_load( 'inners.link', dirname( __DIR__ ) ),
 		),
 	]
 );

--- a/packages/blocks/core/php/wordpress/image/block.php
+++ b/packages/blocks/core/php/wordpress/image/block.php
@@ -13,10 +13,8 @@ return array_merge(
 		'selectors' => array_merge(
 			$args['selectors'] ?? [],
 			[
-				'innerBlocks' => [
-					'elements/caption' => [
-						'root' => 'figcaption',
-					],
+				'blockera/elements/caption' => [
+					'root' => 'figcaption',
 				],
 			]
 		),

--- a/packages/blocks/core/php/wordpress/inners/button.php
+++ b/packages/blocks/core/php/wordpress/inners/button.php
@@ -6,7 +6,7 @@
  */
 
 return [
-	'core/button' => [
+	'blockera/core/button' => [
 		'root' => '.wp-block-button > .wp-element-button',
 	],
 ];

--- a/packages/blocks/core/php/wordpress/inners/headings.php
+++ b/packages/blocks/core/php/wordpress/inners/headings.php
@@ -8,25 +8,25 @@
  */
 
 return [
-	'core/heading' => [
+	'blockera/core/heading' => [
 		'root' => 'h1.wp-block-heading, h2.wp-block-heading, h3.wp-block-heading, h4.wp-block-heading, h5.wp-block-heading, h6.wp-block-heading',
 	],
-	'heading1'     => [
+	'heading1'              => [
 		'root' => 'h1.wp-block-heading',
 	],
-	'heading2'     => [
+	'heading2'              => [
 		'root' => 'h2.wp-block-heading',
 	],
-	'heading3'     => [
+	'heading3'              => [
 		'root' => 'h3.wp-block-heading',
 	],
-	'heading4'     => [
+	'heading4'              => [
 		'root' => 'h4.wp-block-heading',
 	],
-	'heading5'     => [
+	'heading5'              => [
 		'root' => 'h5.wp-block-heading',
 	],
-	'heading6'     => [
+	'heading6'              => [
 		'root' => 'h6.wp-block-heading',
 	],
 ];

--- a/packages/blocks/core/php/wordpress/inners/link.php
+++ b/packages/blocks/core/php/wordpress/inners/link.php
@@ -6,7 +6,7 @@
  */
 
 return [
-	'elements/link' => [
+	'blockera/elements/link' => [
 		'root' => 'a:not(.wp-element-button)',
 	],
 ];

--- a/packages/blocks/core/php/wordpress/inners/numbers.php
+++ b/packages/blocks/core/php/wordpress/inners/numbers.php
@@ -6,13 +6,13 @@
  */
 
 return [
-	'elements/numbers' => [
+	'blockera/elements/numbers' => [
 		'root' => '.page-numbers:not(.dots)',
 	],
-	'elements/current' => [
+	'blockera/elements/current' => [
 		'root' => '.page-numbers.current',
 	],
-	'elements/dots'    => [
+	'blockera/elements/dots'    => [
 		'root' => '.page-numbers.dots',
 	],
 ];

--- a/packages/blocks/core/php/wordpress/inners/paragraph.php
+++ b/packages/blocks/core/php/wordpress/inners/paragraph.php
@@ -6,7 +6,7 @@
  */
 
 return [
-	'core/paragraph' => [
+	'blockera/core/paragraph' => [
 		'root' => 'p',
 	],
 ];

--- a/packages/blocks/core/php/wordpress/latest-comments/block.php
+++ b/packages/blocks/core/php/wordpress/latest-comments/block.php
@@ -13,25 +13,23 @@ return array_merge(
 		'selectors' => array_merge(
 			$args['selectors'] ?? [],
 			[
-				'innerBlocks' => [
-					'elements/container'    => [
-						'root' => '.wp-block-latest-comments__comment',
-					],
-					'elements/avatar'       => [
-						'root' => '.wp-block-latest-comments__comment-avatar',
-					],
-					'elements/author'       => [
-						'root' => '.wp-block-latest-comments__comment-author',
-					],
-					'elements/post-title'   => [
-						'root' => '.wp-block-latest-comments__comment-link',
-					],
-					'elements/date'         => [
-						'root' => '.wp-block-latest-comments__comment-date',
-					],
-					'elements/comment-text' => [
-						'root' => '.wp-block-latest-comments__comment-excerpt',
-					],
+				'blockera/elements/container'    => [
+					'root' => '.wp-block-latest-comments__comment',
+				],
+				'blockera/elements/avatar'       => [
+					'root' => '.wp-block-latest-comments__comment-avatar',
+				],
+				'blockera/elements/author'       => [
+					'root' => '.wp-block-latest-comments__comment-author',
+				],
+				'blockera/elements/post-title'   => [
+					'root' => '.wp-block-latest-comments__comment-link',
+				],
+				'blockera/elements/date'         => [
+					'root' => '.wp-block-latest-comments__comment-date',
+				],
+				'blockera/elements/comment-text' => [
+					'root' => '.wp-block-latest-comments__comment-excerpt',
 				],
 			]
 		),

--- a/packages/blocks/core/php/wordpress/latest-posts/block.php
+++ b/packages/blocks/core/php/wordpress/latest-posts/block.php
@@ -12,9 +12,7 @@ return array_merge(
 	[
 		'selectors' => array_merge(
 			$args['selectors'] ?? [],
-			[
-				'innerBlocks' => blockera_load( 'inners.link', dirname( __DIR__ ) ),
-			]
+			blockera_load( 'inners.link', dirname( __DIR__ ) ),
 		),
 	]
 );

--- a/packages/blocks/core/php/wordpress/list/block.php
+++ b/packages/blocks/core/php/wordpress/list/block.php
@@ -12,9 +12,7 @@ return array_merge(
 	[
 		'selectors' => array_merge(
 			$args['selectors'] ?? [],
-			[
-				'innerBlocks' => blockera_load( 'inners.link', dirname( __DIR__ ) ),
-			]
+			blockera_load( 'inners.link', dirname( __DIR__ ) ),
 		),
 	]
 );

--- a/packages/blocks/core/php/wordpress/loginout/block.php
+++ b/packages/blocks/core/php/wordpress/loginout/block.php
@@ -13,22 +13,20 @@ return array_merge(
 		'selectors' => array_merge(
 			$args['selectors'] ?? [],
 			[
-				'innerBlocks' => [
-					'elements/form'        => [
-						'root' => 'form',
-					],
-					'elements/input-label' => [
-						'root' => '.login-password label, .login-username label',
-					],
-					'elements/input'       => [
-						'root' => '.login-password input, .login-username input',
-					],
-					'elements/remember'    => [
-						'root' => '.login-remember label',
-					],
-					'core/button'          => [
-						'root' => '.login-submit .button.button-primary',
-					],
+				'blockera/elements/form'        => [
+					'root' => 'form',
+				],
+				'blockera/elements/input-label' => [
+					'root' => '.login-password label, .login-username label',
+				],
+				'blockera/elements/input'       => [
+					'root' => '.login-password input, .login-username input',
+				],
+				'blockera/elements/remember'    => [
+					'root' => '.login-remember label',
+				],
+				'blockera/core/button'          => [
+					'root' => '.login-submit .button.button-primary',
 				],
 			]
 		),

--- a/packages/blocks/core/php/wordpress/media-text/block.php
+++ b/packages/blocks/core/php/wordpress/media-text/block.php
@@ -12,19 +12,17 @@ return array_merge(
 	[
 		'selectors' => array_merge(
 			$args['selectors'] ?? [],
-			[
-				'innerBlocks' => array_merge(
-					[
-						'core/image' => [
-							'root' => '.wp-block-media-text__media > img',
-						],
+			(array) array_merge(
+				[
+					'blockera/core/image' => [
+						'root' => '.wp-block-media-text__media > img',
 					],
-					blockera_load( 'inners.link', dirname( __DIR__ ) ),
-					blockera_load( 'inners.button', dirname( __DIR__ ) ),
-					blockera_load( 'inners.headings', dirname( __DIR__ ) ),
-					blockera_load( 'inners.paragraph', dirname( __DIR__ ) ),
-				),
-			]
+				],
+				blockera_load( 'inners.link', dirname( __DIR__ ) ),
+				blockera_load( 'inners.button', dirname( __DIR__ ) ),
+				blockera_load( 'inners.headings', dirname( __DIR__ ) ),
+				blockera_load( 'inners.paragraph', dirname( __DIR__ ) ),
+			)
 		),
 	]
 );

--- a/packages/blocks/core/php/wordpress/paragraph/block.php
+++ b/packages/blocks/core/php/wordpress/paragraph/block.php
@@ -13,10 +13,8 @@ return array_merge(
 		'selectors' => array_merge(
 			$args['selectors'] ?? [],
 			[
-				'innerBlocks' => [
-					'elements/link' => [
-						'root' => 'a:not(.wp-element-button)',
-					],
+				'blockera/elements/link' => [
+					'root' => 'a:not(.wp-element-button)',
 				],
 			]
 		),

--- a/packages/blocks/core/php/wordpress/post-author-biography/block.php
+++ b/packages/blocks/core/php/wordpress/post-author-biography/block.php
@@ -12,9 +12,7 @@ return array_merge(
 	[
 		'selectors' => array_merge(
 			$args['selectors'] ?? [],
-			[
-				'innerBlocks' => blockera_load( 'inners.link', dirname( __DIR__ ) ),
-			]
+			blockera_load( 'inners.link', dirname( __DIR__ ) ),
 		),
 	]
 );

--- a/packages/blocks/core/php/wordpress/post-author-name/block.php
+++ b/packages/blocks/core/php/wordpress/post-author-name/block.php
@@ -12,9 +12,7 @@ return array_merge(
 	[
 		'selectors' => array_merge(
 			$args['selectors'] ?? [],
-			[
-				'innerBlocks' => blockera_load( 'inners.link', dirname( __DIR__ ) ),
-			]
+			blockera_load( 'inners.link', dirname( __DIR__ ) ),
 		),
 	]
 );

--- a/packages/blocks/core/php/wordpress/post-author/block.php
+++ b/packages/blocks/core/php/wordpress/post-author/block.php
@@ -21,22 +21,20 @@ return array_merge(
 		),
 		'selectors'  => array_merge(
 			$args['selectors'] ?? [],
-			[
-				'innerBlocks' => array_merge(
-					blockera_load( 'inners.link', dirname( __DIR__ ) ),
-					[
-						'core/avatar'     => [
-							'root' => '.wp-block-post-author__avatar > img',
-						],
-						'elements/byline' => [
-							'root' => '.wp-block-post-author__byline',
-						],
-						'elements/author' => [
-							'root' => '.wp-block-post-author__name',
-						],
-					]
-				),
-			]
+			(array) array_merge(
+				blockera_load( 'inners.link', dirname( __DIR__ ) ),
+				[
+					'blockera/core/avatar'     => [
+						'root' => '.wp-block-post-author__avatar > img',
+					],
+					'blockera/elements/byline' => [
+						'root' => '.wp-block-post-author__byline',
+					],
+					'blockera/elements/author' => [
+						'root' => '.wp-block-post-author__name',
+					],
+				]
+			)
 		),
 	]
 );

--- a/packages/blocks/core/php/wordpress/post-comments-form/block.php
+++ b/packages/blocks/core/php/wordpress/post-comments-form/block.php
@@ -12,36 +12,34 @@ return array_merge(
 	[
 		'selectors' => array_merge(
 			$args['selectors'] ?? [],
-			[
-				'innerBlocks' => array_merge(
-					[
-						'elements/title'          => [
-							'root' => '.comment-reply-title',
-						],
-						'elements/form'           => [
-							'root' => '.comment-form',
-						],
-						'elements/notes'          => [
-							'root' => '.comment-notes',
-						],
-						'elements/input-label'    => [
-							'root' => 'label',
-						],
-						'elements/input'          => [
-							'root' => 'input[type="text"],input[type="url"],input[type="email"]',
-						],
-						'elements/textarea'       => [
-							'root' => 'textarea',
-						],
-						'elements/cookie-consent' => [
-							'root' => '.comment-form-cookies-consent',
-						],
+			(array) array_merge(
+				[
+					'blockera/elements/title'          => [
+						'root' => '.comment-reply-title',
 					],
-					blockera_load( 'inners.link', dirname( __DIR__ ) ),
-					blockera_load( 'inners.button', dirname( __DIR__ ) ),
-					blockera_load( 'inners.headings', dirname( __DIR__ ) ),
-				),
-			]
+					'blockera/elements/form'           => [
+						'root' => '.comment-form',
+					],
+					'blockera/elements/notes'          => [
+						'root' => '.comment-notes',
+					],
+					'blockera/elements/input-label'    => [
+						'root' => 'label',
+					],
+					'blockera/elements/input'          => [
+						'root' => 'input[type="text"],input[type="url"],input[type="email"]',
+					],
+					'blockera/elements/textarea'       => [
+						'root' => 'textarea',
+					],
+					'blockera/elements/cookie-consent' => [
+						'root' => '.comment-form-cookies-consent',
+					],
+				],
+				blockera_load( 'inners.link', dirname( __DIR__ ) ),
+				blockera_load( 'inners.button', dirname( __DIR__ ) ),
+				blockera_load( 'inners.headings', dirname( __DIR__ ) ),
+			)
 		),
 	]
 );

--- a/packages/blocks/core/php/wordpress/post-content/block.php
+++ b/packages/blocks/core/php/wordpress/post-content/block.php
@@ -12,9 +12,7 @@ return array_merge(
 	[
 		'selectors' => array_merge(
 			$args['selectors'] ?? [],
-			[
-				'innerBlocks' => blockera_load( 'inners.link', dirname( __DIR__ ) ),
-			]
+			blockera_load( 'inners.link', dirname( __DIR__ ) ),
 		),
 	]
 );

--- a/packages/blocks/core/php/wordpress/post-date/block.php
+++ b/packages/blocks/core/php/wordpress/post-date/block.php
@@ -12,9 +12,7 @@ return array_merge(
 	[
 		'selectors' => array_merge(
 			$args['selectors'] ?? [],
-			[
-				'innerBlocks' => blockera_load( 'inners.link', dirname( __DIR__ ) ),
-			]
+			blockera_load( 'inners.link', dirname( __DIR__ ) ),
 		),
 	]
 );

--- a/packages/blocks/core/php/wordpress/post-excerpt/block.php
+++ b/packages/blocks/core/php/wordpress/post-excerpt/block.php
@@ -12,9 +12,7 @@ return array_merge(
 	[
 		'selectors' => array_merge(
 			$args['selectors'] ?? [],
-			[
-				'innerBlocks' => blockera_load( 'inners.link', dirname( __DIR__ ) ),
-			]
+			blockera_load( 'inners.link', dirname( __DIR__ ) ),
 		),
 	]
 );

--- a/packages/blocks/core/php/wordpress/post-navigation-link/block.php
+++ b/packages/blocks/core/php/wordpress/post-navigation-link/block.php
@@ -12,9 +12,7 @@ return array_merge(
 	[
 		'selectors' => array_merge(
 			$args['selectors'] ?? [],
-			[
-				'innerBlocks' => blockera_load( 'inners.link', dirname( __DIR__ ) ),
-			]
+			blockera_load( 'inners.link', dirname( __DIR__ ) ),
 		),
 	]
 );

--- a/packages/blocks/core/php/wordpress/post-template/block.php
+++ b/packages/blocks/core/php/wordpress/post-template/block.php
@@ -20,9 +20,7 @@ return array_merge(
 		),
 		'selectors' => array_merge(
 			$args['selectors'] ?? [],
-			[
-				'innerBlocks' => blockera_load( 'inners.link', dirname( __DIR__ ) ),
-			]
+			blockera_load( 'inners.link', dirname( __DIR__ ) ),
 		),
 	]
 );

--- a/packages/blocks/core/php/wordpress/post-terms/block.php
+++ b/packages/blocks/core/php/wordpress/post-terms/block.php
@@ -12,22 +12,20 @@ return array_merge(
 	[
 		'selectors' => array_merge(
 			$args['selectors'] ?? [],
-			[
-				'innerBlocks' => array_merge(
-					[
-						'elements/separator' => [
-							'root' => '.wp-block-post-terms__separator',
-						],
-						'elements/prefix'    => [
-							'root' => '.wp-block-post-terms__prefix',
-						],
-						'elements/suffix'    => [
-							'root' => '.wp-block-post-terms__suffix',
-						],
+			(array) array_merge(
+				[
+					'blockera/elements/separator' => [
+						'root' => '.wp-block-post-terms__separator',
 					],
-					blockera_load( 'inners.link', dirname( __DIR__ ) ),
-				),
-			]
+					'blockera/elements/prefix'    => [
+						'root' => '.wp-block-post-terms__prefix',
+					],
+					'blockera/elements/suffix'    => [
+						'root' => '.wp-block-post-terms__suffix',
+					],
+				],
+				blockera_load( 'inners.link', dirname( __DIR__ ) ),
+			)
 		),
 	]
 );

--- a/packages/blocks/core/php/wordpress/post-title/block.php
+++ b/packages/blocks/core/php/wordpress/post-title/block.php
@@ -12,9 +12,7 @@ return array_merge(
 	[
 		'selectors' => array_merge(
 			$args['selectors'] ?? [],
-			[
-				'innerBlocks' => blockera_load( 'inners.link', dirname( __DIR__ ) ),
-			]
+			blockera_load( 'inners.link', dirname( __DIR__ ) ),
 		),
 	]
 );

--- a/packages/blocks/core/php/wordpress/pullquote/block.php
+++ b/packages/blocks/core/php/wordpress/pullquote/block.php
@@ -12,17 +12,15 @@ return array_merge(
 	[
 		'selectors' => array_merge(
 			$args['selectors'] ?? [],
-			[
-				'innerBlocks' => array_merge(
-					[
-						'elements/citation' => [
-							'root' => 'cite',
-						],
+			(array) array_merge(
+				[
+					'blockera/elements/citation' => [
+						'root' => 'cite',
 					],
-					blockera_load( 'inners.link', dirname( __DIR__ ) ),
-					blockera_load( 'inners.paragraph', dirname( __DIR__ ) ),
-				),
-			]
+				],
+				blockera_load( 'inners.link', dirname( __DIR__ ) ),
+				blockera_load( 'inners.paragraph', dirname( __DIR__ ) ),
+			)
 		),
 	]
 );

--- a/packages/blocks/core/php/wordpress/query-no-results/block.php
+++ b/packages/blocks/core/php/wordpress/query-no-results/block.php
@@ -12,9 +12,7 @@ return array_merge(
 	[
 		'selectors' => array_merge(
 			$args['selectors'] ?? [],
-			[
-				'innerBlocks' => blockera_load( 'inners.link', dirname( __DIR__ ) ),
-			]
+			blockera_load( 'inners.link', dirname( __DIR__ ) ),
 		),
 	]
 );

--- a/packages/blocks/core/php/wordpress/query-pagination-next/block.php
+++ b/packages/blocks/core/php/wordpress/query-pagination-next/block.php
@@ -13,10 +13,8 @@ return array_merge(
 		'selectors' => array_merge(
 			$args['selectors'] ?? [],
 			[
-				'innerBlocks' => [
-					'elements/arrow' => [
-						'root' => '.wp-block-query-pagination-next-arrow',
-					],
+				'blockera/elements/arrow' => [
+					'root' => '.wp-block-query-pagination-next-arrow',
 				],
 			]
 		),

--- a/packages/blocks/core/php/wordpress/query-pagination-numbers/block.php
+++ b/packages/blocks/core/php/wordpress/query-pagination-numbers/block.php
@@ -12,9 +12,7 @@ return array_merge(
 	[
 		'selectors' => array_merge(
 			$args['selectors'] ?? [],
-			[
-				'innerBlocks' => blockera_load( 'inners.numbers', dirname( __DIR__ ) ),
-			]
+			blockera_load( 'inners.numbers', dirname( __DIR__ ) )
 		),
 	]
 );

--- a/packages/blocks/core/php/wordpress/query-pagination-previous/block.php
+++ b/packages/blocks/core/php/wordpress/query-pagination-previous/block.php
@@ -13,10 +13,8 @@ return array_merge(
 		'selectors' => array_merge(
 			$args['selectors'] ?? [],
 			[
-				'innerBlocks' => [
-					'elements/arrow' => [
-						'root' => '.wp-block-query-pagination-previous-arrow',
-					],
+				'blockera/elements/arrow' => [
+					'root' => '.wp-block-query-pagination-previous-arrow',
 				],
 			]
 		),

--- a/packages/blocks/core/php/wordpress/query-pagination/block.php
+++ b/packages/blocks/core/php/wordpress/query-pagination/block.php
@@ -21,9 +21,7 @@ return array_merge(
 		),
 		'selectors'  => array_merge(
 			$args['selectors'] ?? [],
-			[
-				'innerBlocks' => blockera_load( 'inners.link', dirname( __DIR__ ) ),
-			]
+			blockera_load( 'inners.link', dirname( __DIR__ ) ),
 		),
 	]
 );

--- a/packages/blocks/core/php/wordpress/query-title/block.php
+++ b/packages/blocks/core/php/wordpress/query-title/block.php
@@ -12,9 +12,7 @@ return array_merge(
 	[
 		'selectors' => array_merge(
 			$args['selectors'] ?? [],
-			[
-				'innerBlocks' => blockera_load( 'inners.link', dirname( __DIR__ ) ),
-			]
+			blockera_load( 'inners.link', dirname( __DIR__ ) ),
 		),
 	]
 );

--- a/packages/blocks/core/php/wordpress/quote/block.php
+++ b/packages/blocks/core/php/wordpress/quote/block.php
@@ -20,19 +20,17 @@ return array_merge(
 		),
 		'selectors' => array_merge(
 			$args['selectors'] ?? [],
-			[
-				'innerBlocks' => array_merge(
-					[
-						'elements/citation' => [
-							'root' => 'cite',
-						],
+			(array) array_merge(
+				[
+					'blockera/elements/citation' => [
+						'root' => 'cite',
 					],
-					blockera_load( 'inners.link', dirname( __DIR__ ) ),
-					blockera_load( 'inners.button', dirname( __DIR__ ) ),
-					blockera_load( 'inners.headings', dirname( __DIR__ ) ),
-					blockera_load( 'inners.paragraph', dirname( __DIR__ ) ),
-				),
-			]
+				],
+				blockera_load( 'inners.link', dirname( __DIR__ ) ),
+				blockera_load( 'inners.button', dirname( __DIR__ ) ),
+				blockera_load( 'inners.headings', dirname( __DIR__ ) ),
+				blockera_load( 'inners.paragraph', dirname( __DIR__ ) ),
+			)
 		),
 	]
 );

--- a/packages/blocks/core/php/wordpress/rss/block.php
+++ b/packages/blocks/core/php/wordpress/rss/block.php
@@ -13,22 +13,20 @@ return array_merge(
 		'selectors' => array_merge(
 			$args['selectors'] ?? [],
 			[
-				'innerBlocks' => [
-					'elements/container' => [
-						'root' => '.wp-block-rss__item',
-					],
-					'elements/title'     => [
-						'root' => '.wp-block-rss__item-title',
-					],
-					'elements/date'      => [
-						'root' => '.wp-block-rss__item-publish-date',
-					],
-					'elements/author'    => [
-						'root' => '.wp-block-rss__item-author',
-					],
-					'elements/excerpt'   => [
-						'root' => '.wp-block-rss__item-excerpt',
-					],
+				'blockera/elements/container' => [
+					'root' => '.wp-block-rss__item',
+				],
+				'blockera/elements/title'     => [
+					'root' => '.wp-block-rss__item-title',
+				],
+				'blockera/elements/date'      => [
+					'root' => '.wp-block-rss__item-publish-date',
+				],
+				'blockera/elements/author'    => [
+					'root' => '.wp-block-rss__item-author',
+				],
+				'blockera/elements/excerpt'   => [
+					'root' => '.wp-block-rss__item-excerpt',
 				],
 			]
 		),

--- a/packages/blocks/core/php/wordpress/search/block.php
+++ b/packages/blocks/core/php/wordpress/search/block.php
@@ -13,16 +13,14 @@ return array_merge(
 		'selectors' => array_merge(
 			$args['selectors'] ?? [],
 			[
-				'innerBlocks' => [
-					'elements/label'  => [
-						'root' => '.wp-block-search__label',
-					],
-					'elements/input'  => [
-						'root' => '.wp-block-search__input',
-					],
-					'elements/button' => [
-						'root' => '.wp-block-search__button',
-					],
+				'blockera/elements/label'  => [
+					'root' => '.wp-block-search__label',
+				],
+				'blockera/elements/input'  => [
+					'root' => '.wp-block-search__input',
+				],
+				'blockera/elements/button' => [
+					'root' => '.wp-block-search__button',
 				],
 			]
 		),

--- a/packages/blocks/core/php/wordpress/site-title/block.php
+++ b/packages/blocks/core/php/wordpress/site-title/block.php
@@ -12,9 +12,7 @@ return array_merge(
 	[
 		'selectors' => array_merge(
 			$args['selectors'] ?? [],
-			[
-				'innerBlocks' => blockera_load( 'inners.link', dirname( __DIR__ ) ),
-			]
+			blockera_load( 'inners.link', dirname( __DIR__ ) ),
 		),
 	]
 );

--- a/packages/blocks/core/php/wordpress/social-link/block.php
+++ b/packages/blocks/core/php/wordpress/social-link/block.php
@@ -13,13 +13,11 @@ return array_merge(
 		'selectors' => array_merge(
 			$args['selectors'] ?? [],
 			[
-				'innerBlocks' => [
-					'elements/item-icon' => [
-						'root' => 'svg',
-					],
-					'elements/item-name' => [
-						'root' => '.wp-block-social-link-label',
-					],
+				'blockera/elements/item-icon' => [
+					'root' => 'svg',
+				],
+				'blockera/elements/item-name' => [
+					'root' => '.wp-block-social-link-label',
 				],
 			]
 		),

--- a/packages/blocks/core/php/wordpress/social-links/block.php
+++ b/packages/blocks/core/php/wordpress/social-links/block.php
@@ -22,16 +22,14 @@ return array_merge(
 		'selectors'  => array_merge(
 			$args['selectors'] ?? [],
 			[
-				'innerBlocks' => [
-					'elements/item-containers' => [
-						'root' => '.wp-block-social-link',
-					],
-					'elements/item-icons'      => [
-						'root' => '.wp-block-social-link svg',
-					],
-					'elements/item-names'      => [
-						'root' => '.wp-block-social-link .wp-block-social-link-label',
-					],
+				'blockera/elements/item-containers' => [
+					'root' => '.wp-block-social-link',
+				],
+				'blockera/elements/item-icons'      => [
+					'root' => '.wp-block-social-link svg',
+				],
+				'blockera/elements/item-names'      => [
+					'root' => '.wp-block-social-link .wp-block-social-link-label',
 				],
 			]
 		),

--- a/packages/blocks/core/php/wordpress/term-description/block.php
+++ b/packages/blocks/core/php/wordpress/term-description/block.php
@@ -12,9 +12,7 @@ return array_merge(
 	[
 		'selectors' => array_merge(
 			$args['selectors'] ?? [],
-			[
-				'innerBlocks' => blockera_load( 'inners.link', dirname( __DIR__ ) ),
-			]
+			blockera_load( 'inners.link', dirname( __DIR__ ) ),
 		),
 	]
 );

--- a/packages/blocks/core/php/wordpress/verse/block.php
+++ b/packages/blocks/core/php/wordpress/verse/block.php
@@ -12,9 +12,7 @@ return array_merge(
 	[
 		'selectors' => array_merge(
 			$args['selectors'] ?? [],
-			[
-				'innerBlocks' => blockera_load( 'inners.link', dirname( __DIR__ ) ),
-			]
+			blockera_load( 'inners.link', dirname( __DIR__ ) ),
 		),
 	]
 );

--- a/packages/editor/js/style-engine/hooks/use-computed-css-props.js
+++ b/packages/editor/js/style-engine/hooks/use-computed-css-props.js
@@ -25,6 +25,10 @@ import type {
 import type { InnerBlockType } from '../../extensions/libs/inner-blocks/types';
 import { getBaseBreakpoint } from '../../canvas-editor';
 
+const appendBlockeraPrefix = (blockType: string): string => {
+	return `blockera/${blockType}`;
+};
+
 export const useComputedCssProps = ({
 	state,
 	selectors,
@@ -106,7 +110,7 @@ export const useComputedCssProps = ({
 					...calculatedProps,
 					state: stateType,
 					masterState,
-					selectors: (selectors?.innerBlocks || {})[blockType] || {},
+					selectors: selectors[appendBlockeraPrefix(blockType)] || {},
 					attributes: {
 						...defaultAttributes,
 						...breakpointItem?.attributes,
@@ -121,7 +125,7 @@ export const useComputedCssProps = ({
 			...calculatedProps,
 			state: 'normal',
 			masterState,
-			selectors: (selectors?.innerBlocks || {})[blockType] || {},
+			selectors: selectors[appendBlockeraPrefix(blockType)] || {},
 			attributes: {
 				...defaultAttributes,
 				...attributes,

--- a/packages/editor/js/style-engine/test/style-engine.e2e.cy.js
+++ b/packages/editor/js/style-engine/test/style-engine.e2e.cy.js
@@ -293,9 +293,7 @@ describe('Style Engine Testing ...', () => {
 						.should('have.css', 'transition')
 						.then((transitionValue) => {
 							// Assert the transition value
-							expect(transitionValue).to.includes(
-								'all 0s ease 0s'
-							);
+							expect(transitionValue).to.eq('all');
 						});
 				});
 
@@ -312,9 +310,7 @@ describe('Style Engine Testing ...', () => {
 						.should('have.css', 'transition')
 						.then((transitionValue) => {
 							// Assert the transition value
-							expect(transitionValue).to.includes(
-								'all 0s ease 0s'
-							);
+							expect(transitionValue).to.eq('all');
 						});
 				});
 

--- a/packages/editor/js/style-engine/test/style-engine.e2e.cy.js
+++ b/packages/editor/js/style-engine/test/style-engine.e2e.cy.js
@@ -398,12 +398,12 @@ describe('Style Engine Testing ...', () => {
 					setBlockState('Normal');
 
 					// Set background color.
-					cy.setColorControlValue('BG Color', '#16e2c1');
+					cy.setColorControlValue('BG Color', '#e3178b');
 
 					cy.getBlock('core/paragraph').should(
 						'have.css',
 						'background-color',
-						'rgb(22, 226, 193)'
+						'rgb(227, 23, 139)'
 					);
 					cy.getBlock('core/paragraph')
 						.should('have.css', 'transition')
@@ -420,12 +420,12 @@ describe('Style Engine Testing ...', () => {
 					setBlockState('Hover');
 
 					// Set background color.
-					cy.setColorControlValue('BG Color', '#e3178b');
+					cy.setColorControlValue('BG Color', '#16e2c1');
 
 					cy.getBlock('core/paragraph').should(
 						'have.css',
 						'background-color',
-						'rgb(227, 23, 139)'
+						'rgb(22, 226, 193)'
 					);
 					cy.getBlock('core/paragraph')
 						.should('have.css', 'transition')
@@ -443,7 +443,7 @@ describe('Style Engine Testing ...', () => {
 					cy.getBlock('core/paragraph').should(
 						'have.css',
 						'background-color',
-						'rgb(227, 23, 139)'
+						'rgb(22, 226, 193)'
 					);
 					cy.getBlock('core/paragraph')
 						.should('have.css', 'transition')
@@ -522,7 +522,7 @@ describe('Style Engine Testing ...', () => {
 					cy.get('.blockera-block').should(
 						'have.css',
 						'background-color',
-						'rgb(22, 226, 193)'
+						'rgb(227, 23, 139)'
 					);
 					cy.get('.blockera-block')
 						.should('have.css', 'transition')
@@ -535,7 +535,7 @@ describe('Style Engine Testing ...', () => {
 					cy.get('.blockera-block').should(
 						'have.css',
 						'background-color',
-						'rgb(227, 23, 139)'
+						'rgb(22, 226, 193)'
 					);
 					cy.get('.blockera-block')
 						.should('have.css', 'transition')

--- a/packages/editor/js/style-engine/test/style-engine.e2e.cy.js
+++ b/packages/editor/js/style-engine/test/style-engine.e2e.cy.js
@@ -207,13 +207,14 @@ describe('Style Engine Testing ...', () => {
 			);
 
 			context('add hover on tablet device with assertions', () => {
-				setDevice('Tablet');
-
 				// set hover block state.
 				addBlockState('hover');
 
 				// Set background color.
 				cy.setColorControlValue('BG Color', '#e3178b');
+
+				setDevice('Desktop');
+				setDevice('Tablet');
 
 				cy.getBlock('core/paragraph').should(
 					'have.css',
@@ -279,76 +280,73 @@ describe('Style Engine Testing ...', () => {
 				savePage();
 				redirectToFrontPage();
 
-				// TODO @reza check and fix this
-				// context('base breakpoint', () => {
-				// 	// Set xl-desktop viewport
-				// 	cy.viewport(1441, 1920);
+				context('base breakpoint', () => {
+					// Set xl-desktop viewport
+					cy.viewport(1441, 1920);
 
-				// 	cy.get('.blockera-block').should(
-				// 		'not.have.css',
-				// 		'background-color',
-				// 		'rgb(22, 226, 193)'
-				// 	);
-				// 	cy.get('.blockera-block')
-				// 		.should('have.css', 'transition')
-				// 		.then((transitionValue) => {
-				// 			// Assert the transition value
-				// 			expect(transitionValue).to.includes(
-				// 				'all 0s ease 0s'
-				// 			);
-				// 		});
-				// });
+					cy.get('.blockera-block').should(
+						'not.have.css',
+						'background-color',
+						'rgb(22, 226, 193)'
+					);
+					cy.get('.blockera-block')
+						.should('have.css', 'transition')
+						.then((transitionValue) => {
+							// Assert the transition value
+							expect(transitionValue).to.includes(
+								'all 0s ease 0s'
+							);
+						});
+				});
 
-				// TODO @reza check and fix this
-				// context('xl-desktop', () => {
-				// 	// Set xl-desktop viewport
-				// 	cy.viewport(1441, 1920);
+				context('xl-desktop', () => {
+					// Set xl-desktop viewport
+					cy.viewport(1441, 1920);
 
-				// 	cy.get('.blockera-block').should(
-				// 		'not.have.css',
-				// 		'background-color',
-				// 		'rgb(22, 226, 193)'
-				// 	);
-				// 	cy.get('.blockera-block')
-				// 		.should('have.css', 'transition')
-				// 		.then((transitionValue) => {
-				// 			// Assert the transition value
-				// 			expect(transitionValue).to.includes(
-				// 				'all 0s ease 0s'
-				// 			);
-				// 		});
-				// });
+					cy.get('.blockera-block').should(
+						'not.have.css',
+						'background-color',
+						'rgb(22, 226, 193)'
+					);
+					cy.get('.blockera-block')
+						.should('have.css', 'transition')
+						.then((transitionValue) => {
+							// Assert the transition value
+							expect(transitionValue).to.includes(
+								'all 0s ease 0s'
+							);
+						});
+				});
 
-				// TODO @reza check and fix this
-				// context('tablet', () => {
-				// 	// Set tablet viewport
-				// 	cy.viewport(991, 1368);
+				context('tablet', () => {
+					// Set tablet viewport
+					cy.viewport(991, 1368);
 
-				// 	cy.get('.blockera-block').should(
-				// 		'have.css',
-				// 		'background-color',
-				// 		'rgb(22, 226, 193)'
-				// 	);
-				// 	cy.get('.blockera-block')
-				// 		.should('have.css', 'transition')
-				// 		.then((transitionValue) => {
-				// 			// Assert the transition value
-				// 			expect(transitionValue).to.includes('0.5s');
-				// 		});
+					cy.get('.blockera-block').should(
+						'have.css',
+						'background-color',
+						'rgb(22, 226, 193)'
+					);
+					cy.get('.blockera-block')
+						.should('have.css', 'transition')
+						.then((transitionValue) => {
+							// Assert the transition value
+							expect(transitionValue).to.includes('0.5s');
+						});
 
-				// 	cy.get('.blockera-block').realHover();
-				// 	cy.get('.blockera-block').should(
-				// 		'have.css',
-				// 		'background-color',
-				// 		'rgb(227, 23, 139)'
-				// 	);
-				// 	cy.get('.blockera-block')
-				// 		.should('have.css', 'transition')
-				// 		.then((transitionValue) => {
-				// 			// Assert the transition value
-				// 			expect(transitionValue).to.includes('0.5s');
-				// 		});
-				// });
+					cy.get('.blockera-block').realHover();
+					cy.get('.blockera-block').should(
+						'have.css',
+						'background-color',
+						'rgb(227, 23, 139)'
+					);
+					cy.get('.blockera-block')
+						.should('have.css', 'transition')
+						.then((transitionValue) => {
+							// Assert the transition value
+							expect(transitionValue).to.includes('0.5s');
+						});
+				});
 			});
 		});
 

--- a/packages/editor/php/StyleEngine.php
+++ b/packages/editor/php/StyleEngine.php
@@ -303,8 +303,10 @@ final class StyleEngine {
 			]
 		);
 
+		$selector_id = blockera_append_blockera_block_prefix( $blockType );
+
 		// Exclude inner blocks styles when hasn't any selectors for this context.
-		if ( empty( $selectors[ $blockType ] ) ) {
+		if ( empty( $selectors[ $selector_id ] ) ) {
 
 			return [];
 		}
@@ -312,7 +314,7 @@ final class StyleEngine {
 		$this->definition->flushDeclarations();
 		$this->configureDefinition( $this->definition );
 		$this->definition->setSettings( $settings['attributes'] );
-		$this->definition->setSelectors( $selectors[ $blockType ] );
+		$this->definition->setSelectors( $selectors[ $selector_id ] );
 
 		$cssRules = $this->definition->getCssRules();
 

--- a/packages/editor/php/StyleEngine.php
+++ b/packages/editor/php/StyleEngine.php
@@ -304,7 +304,7 @@ final class StyleEngine {
 		);
 
 		// Exclude inner blocks styles when hasn't any selectors for this context.
-		if ( empty( $selectors['innerBlocks'][ $blockType ] ) ) {
+		if ( empty( $selectors[ $blockType ] ) ) {
 
 			return [];
 		}
@@ -312,7 +312,7 @@ final class StyleEngine {
 		$this->definition->flushDeclarations();
 		$this->configureDefinition( $this->definition );
 		$this->definition->setSettings( $settings['attributes'] );
-		$this->definition->setSelectors( $selectors['innerBlocks'][ $blockType ] );
+		$this->definition->setSelectors( $selectors[ $blockType ] );
 
 		$cssRules = $this->definition->getCssRules();
 

--- a/packages/editor/php/helpers.php
+++ b/packages/editor/php/helpers.php
@@ -122,9 +122,8 @@ if ( ! function_exists( 'blockera_get_block_state_selectors' ) ) {
 		[
 			'block-type'         => $block_type,
 			'pseudo-class'       => $pseudo_class,
-			'is-inner-block'     => $isInner_block,
+			'is-inner-block'     => $is_inner_block,
 			'block-settings'     => $block_settings,
-			'master-block-state' => $master_block_state,
 		] = $args;
 
 		// Provide fallback css selector to use this when $selectors is empty.
@@ -136,7 +135,7 @@ if ( ! function_exists( 'blockera_get_block_state_selectors' ) ) {
 		}
 
 		// Handle inner blocks selectors based on recieved state.
-		if ( $isInner_block ) {
+		if ( $is_inner_block ) {
 
 			$inner_block_id = blockera_append_blockera_block_prefix( $block_type );
 
@@ -165,12 +164,12 @@ if ( ! function_exists( 'blockera_get_block_state_selectors' ) ) {
 			return $selectors;
 		}
 
-		$customClassname = $block_settings['blockeraBlockStates'][ $pseudo_class ]['css-class'] ?? null;
+		$custom_classname = $block_settings['blockeraBlockStates'][ $pseudo_class ]['css-class'] ?? null;
 
 		foreach ( $selectors as $key => $value ) {
 
-			// Excluding inner blocks.
-			if ( false === strpos( $key, 'blockera/' ) ) {
+			// Excluding inner block selector.
+			if ( false !== strpos( $key, 'blockera/' ) ) {
 
 				continue;
 			}
@@ -179,9 +178,9 @@ if ( ! function_exists( 'blockera_get_block_state_selectors' ) ) {
 
 			// Overriding master block selectors with provided custom-class.
 			// Included all selectors without inner blocks selectors.
-			if ( $has_css_class && ! empty( $customClassname ) && is_string( $value ) ) {
+			if ( $has_css_class && ! empty( $custom_classname ) && is_string( $value ) ) {
 
-				$normalizedParent = blockera_get_normalized_selector( $customClassname );
+				$normalizedParent = blockera_get_normalized_selector( $custom_classname );
 				$normalizedParent = str_ends_with( $normalizedParent, ' ' ) ? $normalizedParent : $normalizedParent . ' ';
 
 				// Add pseudo custom css class as suffix into selectors value for current key.
@@ -250,7 +249,7 @@ if ( ! function_exists( 'blockera_get_inner_block_state_selectors' ) ) {
 			'master-block-state' => $masterBlockState,
 		] = $args;
 
-		$customClassname = $blockSettings['blockeraBlockStates'][ $pseudoClass ]['css-class'] ?? null;
+		$custom_classname = $blockSettings['blockeraBlockStates'][ $pseudoClass ]['css-class'] ?? null;
 
 		foreach ( $selectors as $key => $value ) {
 

--- a/packages/editor/php/helpers.php
+++ b/packages/editor/php/helpers.php
@@ -93,6 +93,21 @@ if ( ! function_exists( 'blockera_block_state_validate' ) ) {
 	}
 }
 
+if ( ! function_exists( 'blockera_append_blockera_block_prefix' ) ) {
+
+	/**
+	 * Appending "blockera/" prefix at block type name.
+	 *
+	 * @param string $block_type the block type name.
+	 *
+	 * @return string the block type name with "blockera/" prefix.
+	 */
+	function blockera_append_blockera_block_prefix( string $block_type ): string {
+
+		return "blockera/{$block_type}";
+	}
+}
+
 if ( ! function_exists( 'blockera_get_block_state_selectors' ) ) {
 	/**
 	 * Retrieve block state selectors.
@@ -123,8 +138,10 @@ if ( ! function_exists( 'blockera_get_block_state_selectors' ) ) {
 		// Handle inner blocks selectors based on recieved state.
 		if ( $isInner_block ) {
 
+			$inner_block_id = blockera_append_blockera_block_prefix( $block_type );
+
 			// Validate inner block type.
-			if ( empty( $selectors['innerBlocks'][ $block_type ] ) ) {
+			if ( empty( $selectors[ $inner_block_id ] ) ) {
 
 				return $selectors;
 			}
@@ -134,15 +151,15 @@ if ( ! function_exists( 'blockera_get_block_state_selectors' ) ) {
 					'fallback'   => $selectors['fallback'] ?? '',
 					'parentRoot' => $selectors['root'] ?? $selectors['fallback'] ?? '',
 				],
-				$selectors['innerBlocks'][ $block_type ],
+				$selectors[ $inner_block_id ],
 			);
 
-			$selectors['innerBlocks'][ $block_type ] = blockera_get_inner_block_state_selectors( $innerBlockSelectors, $args );
+			$selectors[ $inner_block_id ] = blockera_get_inner_block_state_selectors( $innerBlockSelectors, $args );
 
 			// Delete custom fallback and parentRoot selector of inner block list.
 			unset(
-				$selectors['innerBlocks'][ $block_type ]['fallback'],
-				$selectors['innerBlocks'][ $block_type ]['parentRoot']
+				$selectors[ $inner_block_id ]['fallback'],
+				$selectors[ $inner_block_id ]['parentRoot']
 			);
 
 			return $selectors;
@@ -153,7 +170,7 @@ if ( ! function_exists( 'blockera_get_block_state_selectors' ) ) {
 		foreach ( $selectors as $key => $value ) {
 
 			// Excluding inner blocks.
-			if ( 'innerBlocks' === $key ) {
+			if ( false === strpos( $key, 'blockera/' ) ) {
 
 				continue;
 			}

--- a/packages/editor/php/tests/Fixtures/StyleEngine/block-state-selectors.php
+++ b/packages/editor/php/tests/Fixtures/StyleEngine/block-state-selectors.php
@@ -44,35 +44,31 @@ return [
 		[
 			'block-settings'     => [],
 			'is-inner-block'     => true,
-			'block-type'         => 'link',
+			'block-type'         => 'elements/link',
 			'master-block-state' => 'normal',
 			'pseudo-class'       => 'hover',
 			'fallback'           => '.fallback-css-selector',
 		],
 		[
-			'border'      => '.wp-block-image img, .wp-block-image .wp-block-image__crop-area, .wp-block-image .components-placeholder',
-			'shadow'      => '.wp-block-image img, .wp-block-image .wp-block-image__crop-area, .wp-block-image .components-placeholder',
-			'filter'      => [
+			'border'        => '.wp-block-image img, .wp-block-image .wp-block-image__crop-area, .wp-block-image .components-placeholder',
+			'shadow'        => '.wp-block-image img, .wp-block-image .wp-block-image__crop-area, .wp-block-image .components-placeholder',
+			'filter'        => [
 				'duotone' => '.wp-block-image img, .wp-block-image .components-placeholder',
 			],
-			'innerBlocks' => [
-				'link' => [
-					'root' => 'a:not(.wp-element-button)',
-				],
+			'blockera/elements/link' => [
+				'root' => 'a:not(.wp-element-button)',
 			],
 		],
 		[
-			'border'      => '.wp-block-image img, .wp-block-image .wp-block-image__crop-area, .wp-block-image .components-placeholder',
-			'shadow'      => '.wp-block-image img, .wp-block-image .wp-block-image__crop-area, .wp-block-image .components-placeholder',
-			'filter'      => [
+			'border'        => '.wp-block-image img, .wp-block-image .wp-block-image__crop-area, .wp-block-image .components-placeholder',
+			'shadow'        => '.wp-block-image img, .wp-block-image .wp-block-image__crop-area, .wp-block-image .components-placeholder',
+			'filter'        => [
 				'duotone' => '.wp-block-image img, .wp-block-image .components-placeholder',
 			],
-			'innerBlocks' => [
-				'link' => [
-					'root' => '.fallback-css-selector a:not(.wp-element-button):hover',
-				],
+			'blockera/elements/link' => [
+				'root' => '.fallback-css-selector a:not(.wp-element-button):hover',
 			],
-			'fallback'    => '.fallback-css-selector',
+			'fallback'      => '.fallback-css-selector',
 		],
 	],
 	[
@@ -85,113 +81,101 @@ return [
 			'fallback'           => '.fallback-css-selector',
 		],
 		[
-			'border'      => '.wp-block-image img, .wp-block-image .wp-block-image__crop-area, .wp-block-image .components-placeholder',
-			'shadow'      => '.wp-block-image img, .wp-block-image .wp-block-image__crop-area, .wp-block-image .components-placeholder',
-			'filter'      => [
+			'border'        => '.wp-block-image img, .wp-block-image .wp-block-image__crop-area, .wp-block-image .components-placeholder',
+			'shadow'        => '.wp-block-image img, .wp-block-image .wp-block-image__crop-area, .wp-block-image .components-placeholder',
+			'filter'        => [
 				'duotone' => '.wp-block-image img, .wp-block-image .components-placeholder',
 			],
-			'innerBlocks' => [
-				'link' => [
-					'root' => 'a:not(.wp-element-button)',
-				],
+			'blockera/elements/link' => [
+				'root' => 'a:not(.wp-element-button)',
 			],
 		],
 		[
-			'border'      => '.wp-block-image img:hover, .wp-block-image .wp-block-image__crop-area:hover, .wp-block-image .components-placeholder:hover',
-			'shadow'      => '.wp-block-image img:hover, .wp-block-image .wp-block-image__crop-area:hover, .wp-block-image .components-placeholder:hover',
-			'filter'      => [
+			'border'        => '.wp-block-image img:hover, .wp-block-image .wp-block-image__crop-area:hover, .wp-block-image .components-placeholder:hover',
+			'shadow'        => '.wp-block-image img:hover, .wp-block-image .wp-block-image__crop-area:hover, .wp-block-image .components-placeholder:hover',
+			'filter'        => [
 				'duotone' => '.wp-block-image img:hover, .wp-block-image .components-placeholder:hover',
 			],
-			'innerBlocks' => [
-				'link' => [
-					'root' => 'a:not(.wp-element-button)',
-				],
+			'blockera/elements/link' => [
+				'root' => 'a:not(.wp-element-button)',
 			],
-			'fallback'    => '.fallback-css-selector:hover',
+			'fallback'      => '.fallback-css-selector:hover',
 		],
 	],
 	[
 		[
 			'block-settings'     => [],
 			'is-inner-block'     => true,
-			'block-type'         => 'link',
+			'block-type'         => 'elements/link',
 			'master-block-state' => 'hover',
 			'pseudo-class'       => 'hover',
 			'fallback'           => '.fallback-css-selector',
 		],
 		[
-			'border'      => '.wp-block-image img, .wp-block-image .wp-block-image__crop-area, .wp-block-image .components-placeholder',
-			'shadow'      => '.wp-block-image img, .wp-block-image .wp-block-image__crop-area, .wp-block-image .components-placeholder',
-			'filter'      => [
+			'border'        => '.wp-block-image img, .wp-block-image .wp-block-image__crop-area, .wp-block-image .components-placeholder',
+			'shadow'        => '.wp-block-image img, .wp-block-image .wp-block-image__crop-area, .wp-block-image .components-placeholder',
+			'filter'        => [
 				'duotone' => '.wp-block-image img, .wp-block-image .components-placeholder',
 			],
-			'innerBlocks' => [
-				'link' => [
-					'root' => 'a:not(.wp-element-button)',
-				],
+			'blockera/elements/link' => [
+				'root' => 'a:not(.wp-element-button)',
 			],
 		],
 		[
-			'border'      => '.wp-block-image img, .wp-block-image .wp-block-image__crop-area, .wp-block-image .components-placeholder',
-			'shadow'      => '.wp-block-image img, .wp-block-image .wp-block-image__crop-area, .wp-block-image .components-placeholder',
-			'filter'      => [
+			'border'        => '.wp-block-image img, .wp-block-image .wp-block-image__crop-area, .wp-block-image .components-placeholder',
+			'shadow'        => '.wp-block-image img, .wp-block-image .wp-block-image__crop-area, .wp-block-image .components-placeholder',
+			'filter'        => [
 				'duotone' => '.wp-block-image img, .wp-block-image .components-placeholder',
 			],
-			'innerBlocks' => [
-				'link' => [
-					'root' => '.fallback-css-selector:hover a:not(.wp-element-button):hover',
-				],
+			'blockera/elements/link' => [
+				'root' => '.fallback-css-selector:hover a:not(.wp-element-button):hover',
 			],
-			'fallback'    => '.fallback-css-selector',
+			'fallback'      => '.fallback-css-selector',
 		],
 	],
 	[
 		[
 			'block-settings'     => [],
 			'is-inner-block'     => true,
-			'block-type'         => 'image',
+			'block-type'         => 'core/image',
 			'master-block-state' => 'hover',
 			'pseudo-class'       => 'hover',
 			'fallback'           => '.fallback-css-selector',
 		],
 		[
-			'root'        => '.wp-block-image',
-			'border'      => '.wp-block-image img, .wp-block-image .wp-block-image__crop-area, .wp-block-image .components-placeholder',
-			'shadow'      => '.wp-block-image img, .wp-block-image .wp-block-image__crop-area, .wp-block-image .components-placeholder',
-			'filter'      => [
+			'root'          => '.wp-block-image',
+			'border'        => '.wp-block-image img, .wp-block-image .wp-block-image__crop-area, .wp-block-image .components-placeholder',
+			'shadow'        => '.wp-block-image img, .wp-block-image .wp-block-image__crop-area, .wp-block-image .components-placeholder',
+			'filter'        => [
 				'duotone' => '.wp-block-image img, .wp-block-image .components-placeholder',
 			],
-			'innerBlocks' => [
-				'link'  => [
-					'root' => 'a:not(.wp-element-button), a.example-secondary-class',
-				],
-				'image' => [
-					'root'   => 'img',
-					'filter' => [
-						'duotone' => 'img, .components-placeholder',
-					],
+			'blockera/elements/link' => [
+				'root' => 'a:not(.wp-element-button), a.example-secondary-class',
+			],
+			'blockera/core/image'    => [
+				'root'   => 'img',
+				'filter' => [
+					'duotone' => 'img, .components-placeholder',
 				],
 			],
 		],
 		[
-			'root'        => '.wp-block-image',
-			'border'      => '.wp-block-image img, .wp-block-image .wp-block-image__crop-area, .wp-block-image .components-placeholder',
-			'shadow'      => '.wp-block-image img, .wp-block-image .wp-block-image__crop-area, .wp-block-image .components-placeholder',
-			'filter'      => [
+			'root'          => '.wp-block-image',
+			'border'        => '.wp-block-image img, .wp-block-image .wp-block-image__crop-area, .wp-block-image .components-placeholder',
+			'shadow'        => '.wp-block-image img, .wp-block-image .wp-block-image__crop-area, .wp-block-image .components-placeholder',
+			'filter'        => [
 				'duotone' => '.wp-block-image img, .wp-block-image .components-placeholder',
 			],
-			'innerBlocks' => [
-				'link'  => [
-					'root' => 'a:not(.wp-element-button), a.example-secondary-class',
-				],
-				'image' => [
-					'root'   => '.wp-block-image:hover img:hover',
-					'filter' => [
-						'duotone' => '.wp-block-image:hover img:hover, .wp-block-image:hover .components-placeholder:hover',
-					],
+			'blockera/elements/link' => [
+				'root' => 'a:not(.wp-element-button), a.example-secondary-class',
+			],
+			'blockera/core/image'    => [
+				'root'   => '.wp-block-image:hover img:hover',
+				'filter' => [
+					'duotone' => '.wp-block-image:hover img:hover, .wp-block-image:hover .components-placeholder:hover',
 				],
 			],
-			'fallback'    => '.fallback-css-selector',
+			'fallback'      => '.fallback-css-selector',
 		],
 	],
 ];


### PR DESCRIPTION
  ## What?
  Fix php fatal error from WordPress scope_selector() core function.