### PR TITLE
feat: implemented compatible block css selector with WP on editor sty…

### DIFF
--- a/packages/editor/js/extensions/libs/background/styles.js
+++ b/packages/editor/js/extensions/libs/background/styles.js
@@ -11,7 +11,10 @@ import { arrayEquals } from '../utils';
 import type { StylesProps } from '../types';
 import { isActiveField } from '../../api/utils';
 import type { CssRule } from '../../../style-engine/types';
-import { computedCssDeclarations, getCssSelector } from '../../../style-engine';
+import {
+	computedCssDeclarations,
+	getCompatibleBlockCssSelector,
+} from '../../../style-engine';
 import { backgroundGenerator, backgroundClipGenerator } from './css-generators';
 
 export const BackgroundStyles = ({
@@ -57,7 +60,7 @@ export const BackgroundStyles = ({
 			blockProps.attributes.blockeraBackground
 		)
 	) {
-		const pickedSelector = getCssSelector({
+		const pickedSelector = getCompatibleBlockCssSelector({
 			...sharedParams,
 			query: 'blockeraBackground',
 			support: 'blockeraBackground',
@@ -89,7 +92,7 @@ export const BackgroundStyles = ({
 			blockeraBackgroundColor !==
 			attributes.blockeraBackgroundColor.default
 		) {
-			const pickedSelector = getCssSelector({
+			const pickedSelector = getCompatibleBlockCssSelector({
 				...sharedParams,
 				query: 'blockeraBackgroundColor',
 				support: 'blockeraBackgroundColor',
@@ -121,7 +124,7 @@ export const BackgroundStyles = ({
 		blockProps.attributes.blockeraBackgroundClip !==
 			attributes.blockeraBackgroundClip.default
 	) {
-		const pickedSelector = getCssSelector({
+		const pickedSelector = getCompatibleBlockCssSelector({
 			...sharedParams,
 			query: 'blockeraBackgroundClip',
 			support: 'blockeraBackgroundClip',

--- a/packages/editor/js/extensions/libs/border-and-shadow/styles.js
+++ b/packages/editor/js/extensions/libs/border-and-shadow/styles.js
@@ -162,7 +162,7 @@ export const BorderAndShadowStyles = ({
 				...sharedParams,
 				query: 'blockeraBorderRadius',
 				support: 'blockeraBorderRadius',
-				fallbackSupportId: 'border-radius',
+				fallbackSupportId: 'border',
 			});
 
 			styleGroup.push({

--- a/packages/editor/js/extensions/libs/border-and-shadow/styles.js
+++ b/packages/editor/js/extensions/libs/border-and-shadow/styles.js
@@ -18,7 +18,10 @@ import {
 } from './css-generators';
 import type { StylesProps } from '../types';
 import type { CssRule } from '../../../style-engine/types';
-import { computedCssDeclarations, getCssSelector } from '../../../style-engine';
+import {
+	computedCssDeclarations,
+	getCompatibleBlockCssSelector,
+} from '../../../style-engine';
 
 export const BorderAndShadowStyles = ({
 	state,
@@ -67,7 +70,7 @@ export const BorderAndShadowStyles = ({
 			blockProps.attributes.blockeraBoxShadow
 		)
 	) {
-		const pickedSelector = getCssSelector({
+		const pickedSelector = getCompatibleBlockCssSelector({
 			...sharedParams,
 			query: 'blockeraBoxShadow',
 			support: 'blockeraBoxShadow',
@@ -94,7 +97,7 @@ export const BorderAndShadowStyles = ({
 		const blockeraOutline = blockProps.attributes.blockeraOutline;
 
 		if (blockeraOutline !== attributes.blockeraOutline.default) {
-			const pickedSelector = getCssSelector({
+			const pickedSelector = getCompatibleBlockCssSelector({
 				...sharedParams,
 				query: 'blockeraOutline',
 				support: 'blockeraOutline',
@@ -122,7 +125,7 @@ export const BorderAndShadowStyles = ({
 		const blockeraBorder = blockProps.attributes.blockeraBorder;
 
 		if (blockeraBorder !== attributes.blockeraBorder.default) {
-			const pickedSelector = getCssSelector({
+			const pickedSelector = getCompatibleBlockCssSelector({
 				...sharedParams,
 				query: 'blockeraBorder',
 				support: 'blockeraBorder',
@@ -155,7 +158,7 @@ export const BorderAndShadowStyles = ({
 				attributes.blockeraBorderRadius.default
 			)
 		) {
-			const pickedSelector = getCssSelector({
+			const pickedSelector = getCompatibleBlockCssSelector({
 				...sharedParams,
 				query: 'blockeraBorderRadius',
 				support: 'blockeraBorderRadius',

--- a/packages/editor/js/extensions/libs/effects/styles.js
+++ b/packages/editor/js/extensions/libs/effects/styles.js
@@ -18,7 +18,10 @@ import {
 	TransitionGenerator,
 	MaskGenerator,
 } from './css-generators';
-import { getCssSelector, computedCssDeclarations } from '../../../style-engine';
+import {
+	getCompatibleBlockCssSelector,
+	computedCssDeclarations,
+} from '../../../style-engine';
 import {
 	AfterDividerGenerator,
 	BeforeDividerGenerator,
@@ -73,7 +76,7 @@ export const EffectsStyles = ({
 		blockProps.attributes.blockeraOpacity !==
 			attributes.blockeraOpacity.default
 	) {
-		const pickedSelector = getCssSelector({
+		const pickedSelector = getCompatibleBlockCssSelector({
 			...sharedParams,
 			query: 'blockeraOpacity',
 			support: 'blockeraOpacity',
@@ -226,7 +229,7 @@ export const EffectsStyles = ({
 		}
 
 		if (transformProperties) {
-			const pickedSelector = getCssSelector({
+			const pickedSelector = getCompatibleBlockCssSelector({
 				...sharedParams,
 				query: 'blockeraTransform',
 				support: 'blockeraTransform',
@@ -256,7 +259,7 @@ export const EffectsStyles = ({
 			blockProps.attributes.blockeraTransition
 		)
 	) {
-		const pickedSelector = getCssSelector({
+		const pickedSelector = getCompatibleBlockCssSelector({
 			...sharedParams,
 			query: 'blockeraTransition',
 			support: 'blockeraTransition',
@@ -285,7 +288,7 @@ export const EffectsStyles = ({
 			blockProps.attributes.blockeraFilter
 		)
 	) {
-		const pickedSelector = getCssSelector({
+		const pickedSelector = getCompatibleBlockCssSelector({
 			...sharedParams,
 			query: 'blockeraFilter',
 			support: 'blockeraFilter',
@@ -314,7 +317,7 @@ export const EffectsStyles = ({
 			blockProps.attributes.blockeraBackdropFilter
 		)
 	) {
-		const pickedSelector = getCssSelector({
+		const pickedSelector = getCompatibleBlockCssSelector({
 			...sharedParams,
 			query: 'blockeraBackdropFilter',
 			support: 'blockeraBackdropFilter',
@@ -341,7 +344,7 @@ export const EffectsStyles = ({
 		blockProps.attributes.blockeraBlendMode !==
 			attributes.blockeraBlendMode.default
 	) {
-		const pickedSelector = getCssSelector({
+		const pickedSelector = getCompatibleBlockCssSelector({
 			...sharedParams,
 			query: 'blockeraBlendMode',
 			support: 'blockeraBlendMode',
@@ -374,7 +377,7 @@ export const EffectsStyles = ({
 			blockProps.attributes.blockeraDivider
 		)
 	) {
-		const pickedSelector = getCssSelector({
+		const pickedSelector = getCompatibleBlockCssSelector({
 			...sharedParams,
 			query: 'blockeraDivider',
 			support: 'blockeraDivider',
@@ -399,7 +402,7 @@ export const EffectsStyles = ({
 		});
 
 		styleGroup.push({
-			selector: getCssSelector({
+			selector: getCompatibleBlockCssSelector({
 				...sharedParams,
 				query: 'blockeraDivider',
 				support: 'blockeraDivider',
@@ -422,7 +425,7 @@ export const EffectsStyles = ({
 			Object.entries(blockProps.attributes?.blockeraDivider)?.length === 2
 		) {
 			styleGroup.push({
-				selector: getCssSelector({
+				selector: getCompatibleBlockCssSelector({
 					...sharedParams,
 					query: 'blockeraDivider',
 					support: 'blockeraDivider',
@@ -451,7 +454,7 @@ export const EffectsStyles = ({
 			blockProps.attributes.blockeraMask
 		)
 	) {
-		const pickedSelector = getCssSelector({
+		const pickedSelector = getCompatibleBlockCssSelector({
 			...sharedParams,
 			query: 'blockeraMask',
 			support: 'blockeraMask',

--- a/packages/editor/js/extensions/libs/effects/test/backdrop-filters.e2e.cy.js
+++ b/packages/editor/js/extensions/libs/effects/test/backdrop-filters.e2e.cy.js
@@ -90,7 +90,7 @@ describe('Backdrop Filters → Functionality', () => {
 			.invoke('text')
 			.should(
 				'include',
-				'backdrop-filter: drop-shadow(50px 30px 40px #cccccc);'
+				'backdrop-filter: drop-shadow(50px 30px 40px #cccccc) !important;'
 			);
 	});
 });

--- a/packages/editor/js/extensions/libs/effects/test/filters.e2e.cy.js
+++ b/packages/editor/js/extensions/libs/effects/test/filters.e2e.cy.js
@@ -89,6 +89,9 @@ describe('Filters → Functionality', () => {
 
 		cy.get('style#blockera-inline-css-inline-css')
 			.invoke('text')
-			.should('include', 'filter: drop-shadow(50px 30px 40px #cccccc);');
+			.should(
+				'include',
+				'filter: drop-shadow(50px 30px 40px #cccccc) !important;'
+			);
 	});
 });

--- a/packages/editor/js/extensions/libs/effects/test/transforms.e2e.cy.js
+++ b/packages/editor/js/extensions/libs/effects/test/transforms.e2e.cy.js
@@ -81,7 +81,7 @@ describe('Transforms → Functionality', () => {
 				.invoke('text')
 				.should(
 					'include',
-					'transform: translate3d(150px, 200px, 100px);'
+					'transform: translate3d(150px, 200px, 100px) !important;'
 				);
 		});
 
@@ -132,7 +132,10 @@ describe('Transforms → Functionality', () => {
 
 			cy.get('style#blockera-inline-css-inline-css')
 				.invoke('text')
-				.should('include', 'transform: scale3d(130%, 130%, 50%);');
+				.should(
+					'include',
+					'transform: scale3d(130%, 130%, 50%) !important;'
+				);
 		});
 
 		it('should update transform, when add value to rotate', () => {
@@ -186,7 +189,7 @@ describe('Transforms → Functionality', () => {
 				.invoke('text')
 				.should(
 					'include',
-					'transform: rotateX(10deg) rotateY(20deg) rotateZ(30deg);'
+					'transform: rotateX(10deg) rotateY(20deg) rotateZ(30deg) !important;'
 				);
 		});
 
@@ -235,7 +238,7 @@ describe('Transforms → Functionality', () => {
 
 			cy.get('style#blockera-inline-css-inline-css')
 				.invoke('text')
-				.should('include', 'transform: skew(10deg, 20deg);');
+				.should('include', 'transform: skew(10deg, 20deg) !important;');
 		});
 	});
 
@@ -278,7 +281,7 @@ describe('Transforms → Functionality', () => {
 				.invoke('text')
 				.should(
 					'include',
-					'transform: perspective(150px) translate3d(0px, 0px, 0px)'
+					'transform: perspective(150px) translate3d(0px, 0px, 0px) !important'
 				);
 		});
 
@@ -316,7 +319,7 @@ describe('Transforms → Functionality', () => {
 
 			cy.get('style#blockera-inline-css-inline-css')
 				.invoke('text')
-				.should('include', 'transform-origin: 50% 50%;');
+				.should('include', 'transform-origin: 50% 50% !important;');
 		});
 
 		it('should update backface-visibility, when add value to backface-visibility', () => {
@@ -348,7 +351,7 @@ describe('Transforms → Functionality', () => {
 
 			cy.get('style#blockera-inline-css-inline-css')
 				.invoke('text')
-				.should('include', 'backface-visibility: hidden;');
+				.should('include', 'backface-visibility: hidden !important;');
 		});
 
 		it('should update perspective, when add value to child perspective', () => {
@@ -424,7 +427,7 @@ describe('Transforms → Functionality', () => {
 
 			cy.get('style#blockera-inline-css-inline-css')
 				.invoke('text')
-				.should('include', 'perspective-origin: 50% 50%;');
+				.should('include', 'perspective-origin: 50% 50% !important;');
 		});
 	});
 });

--- a/packages/editor/js/extensions/libs/flex-child/styles.js
+++ b/packages/editor/js/extensions/libs/flex-child/styles.js
@@ -11,7 +11,10 @@ import { getValueAddonRealValue } from '@blockera/controls';
 import type { StylesProps } from '../types';
 import { isActiveField } from '../../api/utils';
 import type { CssRule } from '../../../style-engine/types';
-import { getCssSelector, computedCssDeclarations } from '../../../style-engine';
+import {
+	getCompatibleBlockCssSelector,
+	computedCssDeclarations,
+} from '../../../style-engine';
 
 export const FlexChildStyles = ({
 	state,
@@ -95,7 +98,7 @@ export const FlexChildStyles = ({
 				break;
 		}
 
-		const pickedSelector = getCssSelector({
+		const pickedSelector = getCompatibleBlockCssSelector({
 			...sharedParams,
 			query: 'blockeraFlexChildSizing',
 			support: 'blockeraFlexChildSizing',
@@ -123,7 +126,7 @@ export const FlexChildStyles = ({
 		_attributes.blockeraFlexChildAlign !==
 			attributes.blockeraFlexChildAlign.default
 	) {
-		const pickedSelector = getCssSelector({
+		const pickedSelector = getCompatibleBlockCssSelector({
 			...sharedParams,
 			query: 'blockeraFlexChildAlign',
 			support: 'blockeraFlexChildAlign',
@@ -175,7 +178,7 @@ export const FlexChildStyles = ({
 				break;
 		}
 
-		const pickedSelector = getCssSelector({
+		const pickedSelector = getCompatibleBlockCssSelector({
 			...sharedParams,
 			query: 'blockeraFlexChildOrder',
 			support: 'blockeraFlexChildOrder',

--- a/packages/editor/js/extensions/libs/layout/styles.js
+++ b/packages/editor/js/extensions/libs/layout/styles.js
@@ -12,7 +12,10 @@ import { prepare } from '@blockera/data-editor';
 import type { StylesProps } from '../types';
 import { isActiveField } from '../../api/utils';
 import type { CssRule } from '../../../style-engine/types';
-import { getCssSelector, computedCssDeclarations } from '../../../style-engine';
+import {
+	getCompatibleBlockCssSelector,
+	computedCssDeclarations,
+} from '../../../style-engine';
 
 export const LayoutStyles = ({
 	state,
@@ -64,7 +67,7 @@ export const LayoutStyles = ({
 		isActiveField(blockeraDisplay) &&
 		_attributes.blockeraDisplay !== attributes.blockeraDisplay.default
 	) {
-		const pickedSelector = getCssSelector({
+		const pickedSelector = getCompatibleBlockCssSelector({
 			...sharedParams,
 			query: 'blockeraDisplay',
 			support: 'blockeraDisplay',
@@ -94,7 +97,7 @@ export const LayoutStyles = ({
 		_attributes?.blockeraFlexLayout !== undefined
 	) {
 		if (_attributes?.blockeraFlexLayout?.direction) {
-			const pickedSelector = getCssSelector({
+			const pickedSelector = getCompatibleBlockCssSelector({
 				...sharedParams,
 				query: 'blockeraFlexLayout.direction',
 				fallbackSupportId: 'flexDirection',
@@ -121,7 +124,7 @@ export const LayoutStyles = ({
 		}
 
 		if (_attributes?.blockeraFlexLayout?.alignItems) {
-			const pickedSelector = getCssSelector({
+			const pickedSelector = getCompatibleBlockCssSelector({
 				...sharedParams,
 				query: 'blockeraFlexLayout.alignItems',
 				fallbackSupportId: 'alignItems',
@@ -148,7 +151,7 @@ export const LayoutStyles = ({
 		}
 
 		if (_attributes?.blockeraFlexLayout?.justifyContent) {
-			const pickedSelector = getCssSelector({
+			const pickedSelector = getCompatibleBlockCssSelector({
 				...sharedParams,
 				query: 'blockeraFlexLayout.justifyContent',
 				fallbackSupportId: 'justifyContent',
@@ -189,7 +192,7 @@ export const LayoutStyles = ({
 			value += '-reverse';
 		}
 
-		const pickedSelector = getCssSelector({
+		const pickedSelector = getCompatibleBlockCssSelector({
 			...sharedParams,
 			query: 'blockeraFlexWrap',
 			support: 'blockeraFlexWrap',
@@ -220,7 +223,7 @@ export const LayoutStyles = ({
 		_attributes.blockeraAlignContent !==
 			attributes.blockeraAlignContent.default
 	) {
-		const pickedSelector = getCssSelector({
+		const pickedSelector = getCompatibleBlockCssSelector({
 			...sharedParams,
 			query: 'blockeraAlignContent',
 			support: 'blockeraAlignContent',
@@ -278,7 +281,7 @@ export const LayoutStyles = ({
 
 			// gap
 			if (gap) {
-				const pickedSelector = getCssSelector({
+				const pickedSelector = getCompatibleBlockCssSelector({
 					...sharedParams,
 					query: 'blockeraGap',
 					support: 'blockeraGap',
@@ -325,7 +328,7 @@ export const LayoutStyles = ({
 			const rows = getValueAddonRealValue(_attributes.blockeraGap?.rows);
 
 			if (rows) {
-				const pickedSelector = getCssSelector({
+				const pickedSelector = getCompatibleBlockCssSelector({
 					...sharedParams,
 					query: 'blockeraGap.rows',
 					fallbackSupportId: 'rowGap',
@@ -374,7 +377,7 @@ export const LayoutStyles = ({
 
 			// if there is gapSuffixClass it means the gap is by margin that that does not supports columns gap
 			if (columns && !gapSuffixClass) {
-				const pickedSelector = getCssSelector({
+				const pickedSelector = getCompatibleBlockCssSelector({
 					...sharedParams,
 					query: 'blockeraGap.columns',
 					fallbackSupportId: 'columnGap',
@@ -407,7 +410,7 @@ export const LayoutStyles = ({
 		 * This variable is false by default but it will be enabled if the style clearing is needed.
 		 */
 		if (removeMarginBlockStart) {
-			const pickedSelector = getCssSelector({
+			const pickedSelector = getCompatibleBlockCssSelector({
 				...sharedParams,
 				query: 'blockeraGap',
 				support: 'blockeraGap',

--- a/packages/editor/js/extensions/libs/mouse/styles.js
+++ b/packages/editor/js/extensions/libs/mouse/styles.js
@@ -6,7 +6,10 @@
 import type { StylesProps } from '../types';
 import { isActiveField } from '../../api/utils';
 import type { CssRule } from '../../../style-engine/types';
-import { getCssSelector, computedCssDeclarations } from '../../../style-engine';
+import {
+	getCompatibleBlockCssSelector,
+	computedCssDeclarations,
+} from '../../../style-engine';
 
 export const MouseStyles = ({
 	state,
@@ -52,7 +55,7 @@ export const MouseStyles = ({
 		isActiveField(blockeraCursor) &&
 		currBlockAttributes.blockeraCursor !== attributes.blockeraCursor.default
 	) {
-		const pickedSelector = getCssSelector({
+		const pickedSelector = getCompatibleBlockCssSelector({
 			...sharedParams,
 			query: 'blockeraCursor',
 			support: 'blockeraCursor',
@@ -82,7 +85,7 @@ export const MouseStyles = ({
 		currBlockAttributes.blockeraUserSelect !==
 			attributes.blockeraUserSelect.default
 	) {
-		const pickedSelector = getCssSelector({
+		const pickedSelector = getCompatibleBlockCssSelector({
 			...sharedParams,
 			query: 'blockeraUserSelect',
 			support: 'blockeraUserSelect',
@@ -113,7 +116,7 @@ export const MouseStyles = ({
 		currBlockAttributes.blockeraPointerEvents !==
 			attributes.blockeraPointerEvents.default
 	) {
-		const pickedSelector = getCssSelector({
+		const pickedSelector = getCompatibleBlockCssSelector({
 			...sharedParams,
 			query: 'blockeraPointerEvents',
 			support: 'blockeraPointerEvents',

--- a/packages/editor/js/extensions/libs/position/styles.js
+++ b/packages/editor/js/extensions/libs/position/styles.js
@@ -11,7 +11,10 @@ import { getValueAddonRealValue } from '@blockera/controls';
 import type { StylesProps } from '../types';
 import { isActiveField } from '../../api/utils';
 import type { CssRule } from '../../../style-engine/types';
-import { getCssSelector, computedCssDeclarations } from '../../../style-engine';
+import {
+	getCompatibleBlockCssSelector,
+	computedCssDeclarations,
+} from '../../../style-engine';
 
 export const PositionStyles = ({
 	state,
@@ -58,7 +61,7 @@ export const PositionStyles = ({
 		_attributes.blockeraPosition !== attributes.blockeraPosition.default &&
 		_attributes.blockeraPosition.type !== 'static'
 	) {
-		const pickedSelector = getCssSelector({
+		const pickedSelector = getCompatibleBlockCssSelector({
 			...sharedParams,
 			query: 'blockeraPosition.type',
 			fallbackSupportId: 'position',
@@ -85,7 +88,7 @@ export const PositionStyles = ({
 			_attributes.blockeraPosition.position?.top
 		);
 		if (positionTop !== '') {
-			const pickedSelector = getCssSelector({
+			const pickedSelector = getCompatibleBlockCssSelector({
 				...sharedParams,
 				query: 'blockeraPosition.position.top',
 				fallbackSupportId: 'positionTop',
@@ -113,7 +116,7 @@ export const PositionStyles = ({
 			_attributes.blockeraPosition.position?.right
 		);
 		if (positionRight !== '') {
-			const pickedSelector = getCssSelector({
+			const pickedSelector = getCompatibleBlockCssSelector({
 				...sharedParams,
 				query: 'blockeraPosition.position.right',
 				fallbackSupportId: 'positionRight',
@@ -141,7 +144,7 @@ export const PositionStyles = ({
 			_attributes.blockeraPosition.position?.bottom
 		);
 		if (positionBottom !== '') {
-			const pickedSelector = getCssSelector({
+			const pickedSelector = getCompatibleBlockCssSelector({
 				...sharedParams,
 				query: 'blockeraPosition.position.bottom',
 				fallbackSupportId: 'positionBottom',
@@ -169,7 +172,7 @@ export const PositionStyles = ({
 			_attributes.blockeraPosition.position?.left
 		);
 		if (positionLeft !== '') {
-			const pickedSelector = getCssSelector({
+			const pickedSelector = getCompatibleBlockCssSelector({
 				...sharedParams,
 				query: 'blockeraPosition.position.left',
 				fallbackSupportId: 'positionLeft',
@@ -197,7 +200,7 @@ export const PositionStyles = ({
 			const zIndex = getValueAddonRealValue(_attributes.blockeraZIndex);
 
 			if (zIndex !== attributes.blockeraZIndex.default) {
-				const pickedSelector = getCssSelector({
+				const pickedSelector = getCompatibleBlockCssSelector({
 					...sharedParams,
 					query: 'blockeraZIndex',
 					support: 'blockeraZIndex',

--- a/packages/editor/js/extensions/libs/size/styles.js
+++ b/packages/editor/js/extensions/libs/size/styles.js
@@ -13,7 +13,10 @@ import { arrayEquals } from '../utils';
 import type { StylesProps } from '../types';
 import { isActiveField } from '../../api/utils';
 import type { CssRule } from '../../../style-engine/types';
-import { getCssSelector, computedCssDeclarations } from '../../../style-engine';
+import {
+	getCompatibleBlockCssSelector,
+	computedCssDeclarations,
+} from '../../../style-engine';
 
 export const SizeStyles = ({
 	state,
@@ -78,7 +81,7 @@ export const SizeStyles = ({
 			value = currentBlockAttributes.width;
 		}
 
-		const pickedSelector = getCssSelector({
+		const pickedSelector = getCompatibleBlockCssSelector({
 			...sharedParams,
 			query: 'blockeraWidth',
 			support: 'blockeraWidth',
@@ -112,7 +115,7 @@ export const SizeStyles = ({
 		);
 
 		if (minWidth !== attributes.blockeraMinWidth.default) {
-			const pickedSelector = getCssSelector({
+			const pickedSelector = getCompatibleBlockCssSelector({
 				...sharedParams,
 				query: 'blockeraMinWidth',
 				support: 'blockeraMinWidth',
@@ -147,7 +150,7 @@ export const SizeStyles = ({
 		);
 
 		if (maxWidth !== attributes.blockeraMaxWidth.default) {
-			const pickedSelector = getCssSelector({
+			const pickedSelector = getCompatibleBlockCssSelector({
 				...sharedParams,
 				query: 'blockeraMaxWidth',
 				support: 'blockeraMaxWidth',
@@ -193,7 +196,7 @@ export const SizeStyles = ({
 		}
 
 		if (value.trim()) {
-			const pickedSelector = getCssSelector({
+			const pickedSelector = getCompatibleBlockCssSelector({
 				...sharedParams,
 				query: 'blockeraHeight',
 				support: 'blockeraHeight',
@@ -228,7 +231,7 @@ export const SizeStyles = ({
 		);
 
 		if (minHeight !== attributes.blockeraMinHeight.default) {
-			const pickedSelector = getCssSelector({
+			const pickedSelector = getCompatibleBlockCssSelector({
 				...sharedParams,
 				query: 'blockeraMinHeight',
 				support: 'blockeraMinHeight',
@@ -263,7 +266,7 @@ export const SizeStyles = ({
 		);
 
 		if (maxHeight !== attributes.blockeraMaxHeight.default) {
-			const pickedSelector = getCssSelector({
+			const pickedSelector = getCompatibleBlockCssSelector({
 				...sharedParams,
 				query: 'blockeraMaxHeight',
 				support: 'blockeraMaxHeight',
@@ -297,7 +300,7 @@ export const SizeStyles = ({
 			currentBlockAttributes.blockeraOverflow !==
 			attributes.blockeraOverflow.default
 		) {
-			const pickedSelector = getCssSelector({
+			const pickedSelector = getCompatibleBlockCssSelector({
 				...sharedParams,
 				query: 'blockeraOverflow',
 				support: 'blockeraOverflow',
@@ -348,7 +351,7 @@ export const SizeStyles = ({
 					value = ratio;
 			}
 
-			const pickedSelector = getCssSelector({
+			const pickedSelector = getCompatibleBlockCssSelector({
 				...sharedParams,
 				query: 'blockeraRatio',
 				support: 'blockeraRatio',
@@ -379,7 +382,7 @@ export const SizeStyles = ({
 		currentBlockAttributes?.blockeraFit &&
 		currentBlockAttributes.blockeraFit !== attributes.blockeraFit.default
 	) {
-		const pickedSelector = getCssSelector({
+		const pickedSelector = getCompatibleBlockCssSelector({
 			...sharedParams,
 			query: 'blockeraFit',
 			support: 'blockeraFit',
@@ -412,7 +415,7 @@ export const SizeStyles = ({
 			attributes.blockeraFitPosition.default
 		)
 	) {
-		const pickedSelector = getCssSelector({
+		const pickedSelector = getCompatibleBlockCssSelector({
 			...sharedParams,
 			query: 'blockeraFitPosition',
 			support: 'blockeraFitPosition',

--- a/packages/editor/js/extensions/libs/spacing/styles.js
+++ b/packages/editor/js/extensions/libs/spacing/styles.js
@@ -14,7 +14,10 @@ import { useBlocksStore } from '../../../hooks';
 import { isActiveField } from '../../api/utils';
 import type { CssRule } from '../../../style-engine/types';
 import type { TSpacingDefaultProps, TCssProps } from './types/spacing-props';
-import { getCssSelector, computedCssDeclarations } from '../../../style-engine';
+import {
+	getCompatibleBlockCssSelector,
+	computedCssDeclarations,
+} from '../../../style-engine';
 
 function updateCssProps(spacingProps: TSpacingDefaultProps): TCssProps {
 	const properties: TCssProps = {};
@@ -121,7 +124,7 @@ export const SpacingStyles = ({
 			? updateCssProps(_attributes.blockeraSpacing)
 			: fallbackProps;
 
-	const pickedSelector = getCssSelector({
+	const pickedSelector = getCompatibleBlockCssSelector({
 		...sharedParams,
 		query: 'blockeraSpacing',
 		support: 'blockeraSpacing',

--- a/packages/editor/js/extensions/libs/typography/styles.js
+++ b/packages/editor/js/extensions/libs/typography/styles.js
@@ -14,7 +14,10 @@ import type { StylesProps } from '../types';
 import { isActiveField } from '../../api/utils';
 import { TextShadowGenerator } from './css-generators';
 import type { CssRule } from '../../../style-engine/types';
-import { computedCssDeclarations, getCssSelector } from '../../../style-engine';
+import {
+	computedCssDeclarations,
+	getCompatibleBlockCssSelector,
+} from '../../../style-engine';
 
 export function TypographyStyles({
 	state,
@@ -74,7 +77,7 @@ export function TypographyStyles({
 		);
 
 		if (blockeraFontSize !== attributes.blockeraFontSize.default) {
-			const pickedSelector = getCssSelector({
+			const pickedSelector = getCompatibleBlockCssSelector({
 				...sharedParams,
 				query: 'blockeraFontSize',
 				support: 'blockeraFontSize',
@@ -107,7 +110,7 @@ export function TypographyStyles({
 		);
 
 		if (blockeraLineHeight !== attributes.blockeraLineHeight.default) {
-			const pickedSelector = getCssSelector({
+			const pickedSelector = getCompatibleBlockCssSelector({
 				...sharedParams,
 				query: 'blockeraLineHeight',
 				support: 'blockeraLineHeight',
@@ -140,7 +143,7 @@ export function TypographyStyles({
 		);
 
 		if (blockeraFontColor !== attributes.blockeraFontColor.default) {
-			const pickedSelector = getCssSelector({
+			const pickedSelector = getCompatibleBlockCssSelector({
 				...sharedParams,
 				query: 'blockeraFontColor',
 				support: 'blockeraFontColor',
@@ -170,7 +173,7 @@ export function TypographyStyles({
 		const blockeraTextAlign = blockProps.attributes.blockeraTextAlign;
 
 		if (blockeraTextAlign !== attributes.blockeraTextAlign.default) {
-			const pickedSelector = getCssSelector({
+			const pickedSelector = getCompatibleBlockCssSelector({
 				...sharedParams,
 				query: 'blockeraTextAlign',
 				support: 'blockeraTextAlign',
@@ -203,7 +206,7 @@ export function TypographyStyles({
 		if (
 			blockeraTextDecoration !== attributes.blockeraTextDecoration.default
 		) {
-			const pickedSelector = getCssSelector({
+			const pickedSelector = getCompatibleBlockCssSelector({
 				...sharedParams,
 				query: 'blockeraTextDecoration',
 				support: 'blockeraTextDecoration',
@@ -233,7 +236,7 @@ export function TypographyStyles({
 		const blockeraFontStyle = blockProps.attributes.blockeraFontStyle;
 
 		if (blockeraFontStyle !== attributes.blockeraFontStyle.default) {
-			const pickedSelector = getCssSelector({
+			const pickedSelector = getCompatibleBlockCssSelector({
 				...sharedParams,
 				query: 'blockeraFontStyle',
 				support: 'blockeraFontStyle',
@@ -266,7 +269,7 @@ export function TypographyStyles({
 		if (
 			blockeraTextTransform !== attributes.blockeraTextTransform.default
 		) {
-			const pickedSelector = getCssSelector({
+			const pickedSelector = getCompatibleBlockCssSelector({
 				...sharedParams,
 				query: 'blockeraTextTransform',
 				support: 'blockeraTextTransform',
@@ -296,7 +299,7 @@ export function TypographyStyles({
 		const blockeraDirection = blockProps.attributes.blockeraDirection;
 
 		if (blockeraDirection !== attributes.blockeraDirection.default) {
-			const pickedSelector = getCssSelector({
+			const pickedSelector = getCompatibleBlockCssSelector({
 				...sharedParams,
 				query: 'blockeraDirection',
 				support: 'blockeraDirection',
@@ -329,7 +332,7 @@ export function TypographyStyles({
 		if (
 			blockeraLetterSpacing !== attributes.blockeraLetterSpacing.default
 		) {
-			const pickedSelector = getCssSelector({
+			const pickedSelector = getCompatibleBlockCssSelector({
 				...sharedParams,
 				query: 'blockeraLetterSpacing',
 				support: 'blockeraLetterSpacing',
@@ -359,7 +362,7 @@ export function TypographyStyles({
 		const blockeraWordSpacing = blockProps.attributes.blockeraWordSpacing;
 
 		if (blockeraWordSpacing !== attributes.blockeraWordSpacing.default) {
-			const pickedSelector = getCssSelector({
+			const pickedSelector = getCompatibleBlockCssSelector({
 				...sharedParams,
 				query: 'blockeraWordSpacing',
 				support: 'blockeraWordSpacing',
@@ -389,7 +392,7 @@ export function TypographyStyles({
 		const blockeraTextIndent = blockProps.attributes.blockeraTextIndent;
 
 		if (blockeraTextIndent !== attributes.blockeraTextIndent.default) {
-			const pickedSelector = getCssSelector({
+			const pickedSelector = getCompatibleBlockCssSelector({
 				...sharedParams,
 				query: 'blockeraTextIndent',
 				support: 'blockeraTextIndent',
@@ -423,7 +426,7 @@ export function TypographyStyles({
 			blockeraTextOrientation !==
 			attributes.blockeraTextOrientation.default
 		) {
-			const pickedSelector = getCssSelector({
+			const pickedSelector = getCompatibleBlockCssSelector({
 				...sharedParams,
 				query: 'blockeraTextOrientation',
 				support: 'blockeraTextOrientation',
@@ -485,7 +488,7 @@ export function TypographyStyles({
 				attributes.blockeraTextColumns.default
 			)
 		) {
-			const pickedSelector = getCssSelector({
+			const pickedSelector = getCompatibleBlockCssSelector({
 				...sharedParams,
 				query: 'blockeraTextColumns',
 				support: 'blockeraTextColumns',
@@ -553,7 +556,7 @@ export function TypographyStyles({
 		const blockeraTextStroke = blockProps.attributes.blockeraTextStroke;
 
 		if (blockeraTextStroke !== attributes.blockeraTextStroke.default) {
-			const pickedSelector = getCssSelector({
+			const pickedSelector = getCompatibleBlockCssSelector({
 				...sharedParams,
 				query: 'blockeraTextStroke',
 				support: 'blockeraTextStroke',
@@ -595,7 +598,7 @@ export function TypographyStyles({
 			blockeraWordBreak !== attributes.blockeraWordBreak.default &&
 			blockeraWordBreak !== 'normal'
 		) {
-			const pickedSelector = getCssSelector({
+			const pickedSelector = getCompatibleBlockCssSelector({
 				...sharedParams,
 				query: 'blockeraWordBreak',
 				support: 'blockeraWordBreak',
@@ -628,7 +631,7 @@ export function TypographyStyles({
 			blockProps.attributes.blockeraTextShadow
 		)
 	) {
-		const pickedSelector = getCssSelector({
+		const pickedSelector = getCompatibleBlockCssSelector({
 			...sharedParams,
 			query: 'blockeraTextShadow',
 			support: 'blockeraTextShadow',

--- a/packages/editor/js/extensions/libs/typography/test/font-color.e2e.cy.js
+++ b/packages/editor/js/extensions/libs/typography/test/font-color.e2e.cy.js
@@ -91,6 +91,9 @@ describe('Font Color → Functionality', () => {
 
 		cy.get('style#blockera-inline-css-inline-css')
 			.invoke('text')
-			.should('include', 'color: var(--wp--preset--color--contrast)');
+			.should(
+				'include',
+				'color: var(--wp--preset--color--contrast) !important'
+			);
 	});
 });

--- a/packages/editor/js/style-engine/get-block-css-selector.js
+++ b/packages/editor/js/style-engine/get-block-css-selector.js
@@ -1,0 +1,119 @@
+// @flow
+
+/**
+ * Internal dependencies
+ */
+import { scopeSelector, getValueFromObjectPath } from './utils';
+
+/**
+ * Cloned from WordPress/gutenberg repository.
+ *
+ * @see @wordpress/block-editor/src/components/global-styles/get-block-css-selector.js
+ *
+ * Determine the CSS selector for the block type and target provided, returning
+ * it if available.
+ *
+ * @param {Object} blockType        The block's type.
+ * @param {string|string[]}                   target           The desired selector's target e.g. `root`, delimited string, or array path.
+ * @param {Object}                            options          Options object.
+ * @param {boolean}                           options.fallback Whether or not to fallback to broader selector.
+ *
+ * @return {?string} The CSS selector or `null` if no selector available.
+ */
+export function getBlockCSSSelector(
+	blockType: Object,
+	target: Array<string> | string = 'root',
+	options: { fallback?: boolean } = {}
+): ?string {
+	if (!target) {
+		return null;
+	}
+
+	const { fallback = false } = options;
+	const { name, selectors, supports } = blockType;
+
+	const hasSelectors = selectors && Object.keys(selectors).length > 0;
+	const path = Array.isArray(target) ? target.join('.') : target;
+
+	// Root selector.
+
+	// Calculated before returning as it can be used as a fallback for feature
+	// selectors later on.
+	let rootSelector = null;
+
+	if (hasSelectors && selectors.root) {
+		// Use the selectors API if available.
+		rootSelector = selectors?.root;
+	} else if (supports?.__experimentalSelector) {
+		// Use the old experimental selector supports property if set.
+		rootSelector = supports.__experimentalSelector;
+	} else {
+		// If no root selector found, generate default block class selector.
+		rootSelector =
+			'.wp-block-' + name.replace('core/', '').replace('/', '-');
+	}
+
+	// Return selector if it's the root target we are looking for.
+	if (path === 'root') {
+		return rootSelector;
+	}
+
+	// If target is not `root` or `duotone` we have a feature or subfeature
+	// as the target. If the target is a string convert to an array.
+	const pathArray = Array.isArray(target) ? target : target.split('.');
+
+	// Feature selectors ( may fallback to root selector );
+	if (pathArray.length === 1) {
+		const fallbackSelector = fallback ? rootSelector : null;
+
+		// Prefer the selectors API if available.
+		if (hasSelectors) {
+			// Get selector from either `feature.root` or shorthand path.
+			const featureSelector =
+				getValueFromObjectPath(selectors, `${path}.root`, null) ||
+				getValueFromObjectPath(selectors, path, null);
+
+			// Return feature selector if found or any available fallback.
+			return featureSelector || fallbackSelector;
+		}
+
+		// Try getting old experimental supports selector value.
+		const featureSelector = getValueFromObjectPath(
+			supports,
+			`${path}.__experimentalSelector`,
+			null
+		);
+
+		// If nothing to work with, provide fallback selector if available.
+		if (!featureSelector) {
+			return fallbackSelector;
+		}
+
+		// Scope the feature selector by the block's root selector.
+		return scopeSelector(rootSelector, featureSelector);
+	}
+
+	// Subfeature selector.
+	// This may fallback either to parent feature or root selector.
+	let subfeatureSelector;
+
+	// Use selectors API if available.
+	if (hasSelectors) {
+		subfeatureSelector = getValueFromObjectPath(selectors, path, null);
+	}
+
+	// Only return if we have a subfeature selector.
+	if (subfeatureSelector) {
+		return subfeatureSelector;
+	}
+
+	// To this point we don't have a subfeature selector. If a fallback has been
+	// requested, remove subfeature from target path and return results of a
+	// call for the parent feature's selector.
+	if (fallback) {
+		return getBlockCSSSelector(blockType, pathArray[0], options);
+	}
+
+	// We tried.
+	return null;
+}

--- a/packages/editor/js/style-engine/get-compatible-block-css-selector.js
+++ b/packages/editor/js/style-engine/get-compatible-block-css-selector.js
@@ -270,7 +270,11 @@ export const getCompatibleBlockCssSelector = ({
 	});
 
 	if (selector && selector.trim()) {
-		register(appendRootBlockCssSelector(selector, rootSelector));
+		if (isInnerBlock(currentBlock)) {
+			register(selector);
+		} else {
+			register(appendRootBlockCssSelector(selector, rootSelector));
+		}
 	} else {
 		register(rootSelector);
 	}

--- a/packages/editor/js/style-engine/get-compatible-block-css-selector.js
+++ b/packages/editor/js/style-engine/get-compatible-block-css-selector.js
@@ -8,8 +8,7 @@ import { select } from '@wordpress/data';
 /**
  * Blockera dependencies
  */
-import { prepare } from '@blockera/data-editor';
-import { isString, isUndefined } from '@blockera/utils';
+import { isUndefined } from '@blockera/utils';
 import { isInnerBlock } from '../extensions/components/utils';
 import type { TStates } from '../extensions/libs/block-states/types';
 import type { InnerBlockType } from '../extensions/libs/inner-blocks/types';
@@ -17,15 +16,17 @@ import type { InnerBlockType } from '../extensions/libs/inner-blocks/types';
 /**
  * Internal dependencies
  */
-import { getSelector } from './utils';
+import { replaceVariablesValue } from './utils';
 import { getBaseBreakpoint } from '../canvas-editor';
 import type { NormalizedSelectorProps } from './types';
 import { isNormalState } from '../extensions/components';
+import { getBlockCSSSelector } from './get-block-css-selector';
 
-export const getCssSelector = ({
+export const getCompatibleBlockCssSelector = ({
 	state,
 	query,
 	support,
+	supports,
 	clientId,
 	blockName,
 	masterState,
@@ -252,28 +253,30 @@ export const getCssSelector = ({
 		}
 	};
 
-	// preparing css selector from support path as key in block selectors map as object.
-	// eslint-disable-next-line @wordpress/no-unused-vars-before-return
-	const selector = prepareCssSelector({
-		query,
-		support,
-		fallbackSupportId,
-		selectors: blockSelectors,
-	});
-
 	// FIXME: after implements parent-hover infrastructure please remove exclude this pseudo-class!
 	if (['parent-hover'].includes(state)) {
 		// TODO: implements ...
 		return '';
 	}
 
+	// preparing css selector from support path as key in block selectors map as object.
+	const selector = prepareBlockCssSelector({
+		query,
+		support,
+		supports,
+		blockName,
+		fallbackSupportId,
+		selectors: blockSelectors,
+	});
+
 	if (selector && selector.trim()) {
-		register(selector);
+		register(`${selector}, ${rootSelector}${selector}`);
 	} else {
 		register(rootSelector);
 	}
 
-	return getSelector({
+	// Replace: {{BLOCK_ID}} and {{className}} with values on prepared block selector.
+	return replaceVariablesValue({
 		state,
 		clientId,
 		selectors,
@@ -285,38 +288,56 @@ export const getCssSelector = ({
 /**
  * Retrieve css selector with selectors dataset , support id and query string.
  *
- * @param {{support:string,selectors:Object,query:string,fallbackSupportId:string}} props
+ * @param {{support:string,supports:Object,blockName:string,selectors:Object,query:string,fallbackSupportId:string}} params the params to preparing block css selector.
  *
- * @return {string} the css selector for support
+ * @return {string} the css selector for support.
  */
-export function prepareCssSelector(props: {
-	support?: string,
-	selectors: Object,
+export function prepareBlockCssSelector(params: {
 	query?: string,
+	support?: string,
+	supports: Object,
+	blockName: string,
+	selectors: Object,
 	fallbackSupportId?: string,
 }): string | void {
-	const { support, selectors, query, fallbackSupportId } = props;
+	const {
+		query,
+		support,
+		supports,
+		blockName,
+		selectors,
+		fallbackSupportId,
+	} = params;
 
-	//Preparing selector with query of support.
-	const selector = prepare(query, selectors);
+	const blockType = {
+		name: blockName,
+		supports,
+		selectors,
+	};
 
-	//Fallback for sub feature of support to return selector
+	// Preparing selector with query of support.
+	const selector = getBlockCSSSelector(blockType, query);
+
+	// Fallback for sub feature of support to return selector.
 	if (!selector) {
-		if (isUndefined(support) || isUndefined(selectors[support])) {
-			return !isUndefined(fallbackSupportId)
-				? prepareCssSelector({
-						...props,
-						support: fallbackSupportId,
-						fallbackSupportId: undefined,
-				  })
-				: selectors.root;
+		if (isUndefined(support)) {
+			return (
+				getBlockCSSSelector(blockType, fallbackSupportId || 'root', {
+					fallback: true,
+				}) ||
+				selectors[support].root ||
+				selectors.root
+			);
 		}
 
-		return isString(selectors[support])
-			? selectors[support]
-			: selectors[support].root || selectors.root;
+		// Preparing selector with support identifier.
+		return (
+			getBlockCSSSelector(blockType, support, { fallback: true }) ||
+			selectors[support].root ||
+			selectors.root
+		);
 	}
 
-	//Selector for sub feature of support
+	// Prepared selector with query of support ids like: 'a.b.c.d'.
 	return selector;
 }

--- a/packages/editor/js/style-engine/hooks/use-computed-css-props.js
+++ b/packages/editor/js/style-engine/hooks/use-computed-css-props.js
@@ -22,12 +22,9 @@ import type {
 	TBreakpoint,
 	TStates,
 } from '../../extensions/libs/block-states/types';
+import { appendBlockeraPrefix } from '../utils';
 import type { InnerBlockType } from '../../extensions/libs/inner-blocks/types';
 import { getBaseBreakpoint } from '../../canvas-editor';
-
-const appendBlockeraPrefix = (blockType: string): string => {
-	return `blockera/${blockType}`;
-};
 
 export const useComputedCssProps = ({
 	state,

--- a/packages/editor/js/style-engine/index.js
+++ b/packages/editor/js/style-engine/index.js
@@ -6,7 +6,7 @@ export {
 	injectHelpersToCssGenerators,
 } from './utils';
 
-export { getCssSelector } from './get-css-selector';
+export { getCompatibleBlockCssSelector } from './get-compatible-block-css-selector';
 
 export { default as CssGenerator } from './css-generator';
 

--- a/packages/editor/js/style-engine/types/css-selectors.js
+++ b/packages/editor/js/style-engine/types/css-selectors.js
@@ -14,6 +14,7 @@ export type NormalizedSelectorProps = {
 	state: TStates,
 	clientId: string,
 	support?: string,
+	supports: Object,
 	blockName: string,
 	className?: string,
 	masterState?: TStates,

--- a/packages/editor/js/style-engine/types/css-selectors.js
+++ b/packages/editor/js/style-engine/types/css-selectors.js
@@ -14,7 +14,7 @@ export type NormalizedSelectorProps = {
 	state: TStates,
 	clientId: string,
 	support?: string,
-	supports: Object,
+	supports?: Object,
 	blockName: string,
 	className?: string,
 	masterState?: TStates,

--- a/packages/editor/js/style-engine/utils.js
+++ b/packages/editor/js/style-engine/utils.js
@@ -196,13 +196,13 @@ export function getVars(queries: string): Array<string> {
 	return replacements;
 }
 
-export const getSelector = ({
-	state,
-	clientId,
-	className,
-	selectors,
-	currentBlock,
-}: {
+/**
+ * Replacing variable values on block selector.
+ *
+ * @param {Object} params the parameters to replace variables (Like: {{BLOCK_ID}}, {{className}}) of block selector.
+ * @return {string|string} the block selector with variable values.
+ */
+export const replaceVariablesValue = (params: {
 	state: TStates,
 	clientId: string,
 	className: string,
@@ -213,6 +213,8 @@ export const getSelector = ({
 	},
 	currentBlock: 'master' | InnerBlockType | string,
 }): string => {
+	const { state, clientId, className, selectors, currentBlock } = params;
+
 	if (!state) {
 		return '';
 	}
@@ -267,4 +269,72 @@ export const combineDeclarations = (
 	});
 
 	return Object.values(combinedObjects);
+};
+
+/**
+ * Cloned from WordPress/gutenberg repository.
+ *
+ * @see @wordpress/block-editor/src/components/global-styles/utils.js on line 366
+ *
+ * Function that scopes a selector with another one. This works a bit like
+ * SCSS nesting except the `&` operator isn't supported.
+ *
+ * @example
+ * ```js
+ * const scope = '.a, .b .c';
+ * const selector = '> .x, .y';
+ * const merged = scopeSelector( scope, selector );
+ * // merged is '.a > .x, .a .y, .b .c > .x, .b .c .y'
+ * ```
+ *
+ * @param {string} scope    Selector to scope to.
+ * @param {string} selector Original selector.
+ *
+ * @return {string} Scoped selector.
+ */
+export function scopeSelector(scope: string, selector: string): string {
+	if (!scope || !selector) {
+		return selector;
+	}
+
+	const scopes = scope.split(',');
+	const selectors = selector.split(',');
+
+	const selectorsScoped = [];
+	scopes.forEach((outer) => {
+		selectors.forEach((inner) => {
+			selectorsScoped.push(`${outer.trim()} ${inner.trim()}`);
+		});
+	});
+
+	return selectorsScoped.join(', ');
+}
+
+/**
+ * Cloned from WordPress/gutenberg repository.
+ *
+ * @see @wordpress/block-editor/src/utils/object.js on line 44
+ *
+ * Helper util to return a value from a certain path of the object.
+ * Path is specified as either:
+ * - a string of properties, separated by dots, for example: "x.y".
+ * - an array of properties, for example `[ 'x', 'y' ]`.
+ * You can also specify a default value in case the result is nullish.
+ *
+ * @param {Object}       object       Input object.
+ * @param {string|Array} path         Path to the object property.
+ * @param {*}            defaultValue Default value if the value at the specified path is nullish.
+ * @return {*} Value of the object property at the specified path.
+ */
+export const getValueFromObjectPath = (
+	object: Object,
+	path: string,
+	defaultValue: any
+): any => {
+	const arrayPath = Array.isArray(path) ? path : path.split('.');
+	let value = object;
+	arrayPath.forEach((fieldName) => {
+		value = value?.[fieldName];
+	});
+	return value ?? defaultValue;
 };

--- a/packages/editor/js/style-engine/utils.js
+++ b/packages/editor/js/style-engine/utils.js
@@ -338,3 +338,13 @@ export const getValueFromObjectPath = (
 	});
 	return value ?? defaultValue;
 };
+
+/**
+ * Appending "blockera/" word as prefix.
+ *
+ * @param {string} blockType The block type name.
+ * @return {string} The string start with "blockera/" prefix.
+ */
+export const appendBlockeraPrefix = (blockType: string): string => {
+	return `blockera/${blockType}`;
+};

--- a/packages/editor/php/StyleDefinitions/Background.php
+++ b/packages/editor/php/StyleDefinitions/Background.php
@@ -10,15 +10,6 @@ namespace Blockera\Editor\StyleDefinitions;
 class Background extends BaseStyleDefinition {
 
 	/**
-	 * Hold collection of options to generate style
-	 *
-	 * @var array
-	 */
-	protected array $options = [
-		'is-important' => true,
-	];
-
-	/**
 	 * Hold default props for background stack properties
 	 *
 	 * @var array|string[]
@@ -117,7 +108,7 @@ class Background extends BaseStyleDefinition {
 
 			case 'background-color':
 				$declaration = [
-					$cssProperty => blockera_get_value_addon_real_value( $setting[ $cssProperty ] ) . $this->getImportant(),
+					$cssProperty => blockera_get_value_addon_real_value( $setting[ $cssProperty ] ),
 				];
 				break;
 
@@ -196,15 +187,15 @@ class Background extends BaseStyleDefinition {
 
 		$props = [
 			// Background Image.
-			'background-image'      => "url('{$setting['image']}'){$this->getImportant()}",
+			'background-image'      => "url('{$setting['image']}')",
 			// Background Size.
-			'background-size'       => $size . $this->getImportant(),
+			'background-size'       => $size,
 			// Background Position.
-			'background-position'   => ( $left . ' ' . $top ) . $this->getImportant(),
+			'background-position'   => ( $left . ' ' . $top ),
 			// Background Repeat.
-			'background-repeat'     => ( $setting['image-repeat'] ?? '' ) . $this->getImportant(),
+			'background-repeat'     => ( $setting['image-repeat'] ?? '' ),
 			// Background Attachment.
-			'background-attachment' => ( $setting['image-attachment'] ?? '' ) . $this->getImportant(),
+			'background-attachment' => ( $setting['image-attachment'] ?? '' ),
 		];
 
 		$this->setDeclarations( $this->modifyProperties( $props ) );
@@ -245,9 +236,9 @@ class Background extends BaseStyleDefinition {
 			$this->default_props,
 			[
 				// Background Image.
-				'background-image'      => $gradient . $this->getImportant(),
+				'background-image'      => $gradient,
 				// Background Attachment.
-				'background-attachment' => ( $setting['linear-gradient-attachment'] ?? 'scroll' ) . $this->getImportant(),
+				'background-attachment' => ( $setting['linear-gradient-attachment'] ?? 'scroll' ),
 			]
 		);
 
@@ -273,9 +264,9 @@ class Background extends BaseStyleDefinition {
 				$this->default_props,
 				[
 					// Background Image.
-					'background-image'      => $gradient . $this->getImportant(),
+					'background-image'      => $gradient,
 					// Background Attachment.
-					'background-attachment' => ( $setting['radial-gradient-attachment'] ?? 'scroll' ) . $this->getImportant(),
+					'background-attachment' => ( $setting['radial-gradient-attachment'] ?? 'scroll' ),
 				]
 			);
 		} else {
@@ -316,11 +307,11 @@ class Background extends BaseStyleDefinition {
 				$this->default_props,
 				[
 					// Background Image.
-					'background-image'      => $gradient . $this->getImportant(),
+					'background-image'      => $gradient,
 					// Background Repeat.
-					'background-repeat'     => ( $setting['radial-gradient-repeat'] ?? $this->default_props['repeat'] ) . $this->getImportant(),
+					'background-repeat'     => ( $setting['radial-gradient-repeat'] ?? $this->default_props['repeat'] ),
 					// Background Attachment.
-					'background-attachment' => ( $setting['radial-gradient-attachment'] ?? 'scroll' ) . $this->getImportant(),
+					'background-attachment' => ( $setting['radial-gradient-attachment'] ?? 'scroll' ),
 				]
 			);
 		}
@@ -371,11 +362,11 @@ class Background extends BaseStyleDefinition {
 			$this->default_props,
 			[
 				// override bg color.
-				'background-color'      => ( array_values( $colors )[0]['color'] ? blockera_get_value_addon_real_value( array_values( $colors )[0]['color'] ) : '' ) . $this->getImportant(),
+				'background-color'      => ( array_values( $colors )[0]['color'] ? blockera_get_value_addon_real_value( array_values( $colors )[0]['color'] ) : '' ),
 				// Image.
-				'background-image'      => $gradient . $this->getImportant(),
+				'background-image'      => $gradient,
 				// Background Attachment.
-				'background-attachment' => $setting['mesh-gradient-attachment'] . $this->getImportant(),
+				'background-attachment' => $setting['mesh-gradient-attachment'],
 			]
 		);
 

--- a/packages/editor/php/StyleDefinitions/BaseStyleDefinition.php
+++ b/packages/editor/php/StyleDefinitions/BaseStyleDefinition.php
@@ -69,7 +69,7 @@ abstract class BaseStyleDefinition {
 	 * @var array
 	 */
 	protected array $options = [
-		'is-important' => false,
+		'is-important' => true,
 	];
 
 	public function setOptions( array $options ): void {
@@ -91,7 +91,7 @@ abstract class BaseStyleDefinition {
 	/**
 	 * Sets suitable css selector for related property.
 	 *
-	 * @param string $featureId The feature identifier.
+	 * @param string $featureId   The feature identifier.
 	 * @param string $suffixClass The suffix css class.
 	 */
 	public function setSelector( string $featureId, string $suffixClass = '' ): void {
@@ -99,7 +99,18 @@ abstract class BaseStyleDefinition {
 		$selectors  = $this->getSelectors();
 		$fallbackId = $this->calculateFallbackFeatureId( $featureId );
 
-		$this->selector = blockera_calculate_feature_css_selector( $selectors, $featureId, $fallbackId ) . $suffixClass;
+		$this->selector = sprintf(
+			'%s%s',
+			blockera_get_compatible_block_css_selector(
+				$selectors,
+				$featureId,
+				[
+					'fallback'  => $fallbackId,
+					'blockName' => $this->block['blockName'],
+				]
+			),
+			$suffixClass
+		);
 	}
 
 	/**
@@ -109,7 +120,7 @@ abstract class BaseStyleDefinition {
 	 *
 	 * @return void
 	 */
-	public function setConfig( array $config ):void {
+	public function setConfig( array $config ): void {
 
 		$this->config = $config;
 	}
@@ -209,6 +220,17 @@ abstract class BaseStyleDefinition {
 	 * @param array $declaration the generated css declarations array.
 	 */
 	public function setCss( array $declaration ): void {
+
+		if ( $this->isImportant() ) {
+
+			$declaration = array_map(
+				function ( string $declaration_item ): string {
+
+					return $declaration_item . $this->getImportant();
+				},
+				$declaration
+			);
+		}
 
 		if ( isset( $this->css[ $this->getSelector() ] ) ) {
 

--- a/packages/editor/php/StyleDefinitions/Border.php
+++ b/packages/editor/php/StyleDefinitions/Border.php
@@ -26,7 +26,7 @@ class Border extends BaseStyleDefinition {
 			return $declaration;
 		}
 
-		$this->setSelector( $cssProperty );
+		$this->setSelector( 'border' );
 
 		switch ( $cssProperty ) {
 			case 'border':

--- a/packages/editor/php/StyleDefinitions/Mouse.php
+++ b/packages/editor/php/StyleDefinitions/Mouse.php
@@ -24,7 +24,7 @@ class Mouse extends BaseStyleDefinition {
 
 		$this->setCss(
 			[
-				$cssProperty => $setting[ $cssProperty ] . $this->getImportant(),
+				$cssProperty => $setting[ $cssProperty ],
 			]
 		);
 

--- a/packages/editor/php/StyleDefinitions/Size.php
+++ b/packages/editor/php/StyleDefinitions/Size.php
@@ -34,16 +34,15 @@ class Size extends BaseStyleDefinition {
 				if ( 'custom' === $setting[ $cssProperty ]['value'] ) {
 
 					$declaration[ $cssProperty ] = sprintf(
-						'%1$s%2$s%3$s%4$s',
+						'%1$s%2$s%3$s',
 						$setting[ $cssProperty ]['width'],
 						! empty( $setting[ $cssProperty ]['width'] ) && ! empty( $setting[ $cssProperty ]['height'] ) ? ' / ' : '',
-						$setting[ $cssProperty ]['height'],
-						$this->getImportant()
+						$setting[ $cssProperty ]['height']
 					);
 
 				} else {
 
-					$declaration[ $cssProperty ] = $setting[ $cssProperty ]['value'] . $this->getImportant();
+					$declaration[ $cssProperty ] = $setting[ $cssProperty ]['value'];
 				}
 
 				$this->setCss( $declaration );
@@ -54,15 +53,14 @@ class Size extends BaseStyleDefinition {
 				$declaration[ $cssProperty ] = sprintf(
 					'%1$s %2$s%3$s',
 					$setting[ $cssProperty ]['top'],
-					$setting[ $cssProperty ]['left'],
-					$this->getImportant()
+					$setting[ $cssProperty ]['left']
 				);
 
 				$this->setCss( $declaration );
 				break;
 
 			default:
-				$declaration[ $cssProperty ] = blockera_get_value_addon_real_value( $setting[ $cssProperty ] ) . $this->getImportant();
+				$declaration[ $cssProperty ] = blockera_get_value_addon_real_value( $setting[ $cssProperty ] );
 
 				$this->setCss( $declaration );
 				break;

--- a/packages/editor/php/StyleDefinitions/Size.php
+++ b/packages/editor/php/StyleDefinitions/Size.php
@@ -51,7 +51,7 @@ class Size extends BaseStyleDefinition {
 
 			case 'object-position':
 				$declaration[ $cssProperty ] = sprintf(
-					'%1$s %2$s%3$s',
+					'%1$s %2$s',
 					$setting[ $cssProperty ]['top'],
 					$setting[ $cssProperty ]['left']
 				);

--- a/packages/editor/php/StyleDefinitions/Spacing.php
+++ b/packages/editor/php/StyleDefinitions/Spacing.php
@@ -4,10 +4,6 @@ namespace Blockera\Editor\StyleDefinitions;
 
 class Spacing extends BaseStyleDefinition {
 
-	protected array $options = [
-		'is-important' => true,
-	];
-
 	/**
 	 * @inheritDoc
 	 *
@@ -58,21 +54,19 @@ class Spacing extends BaseStyleDefinition {
 			);
 		}
 
-		$isImportant = $this->getImportant();
-
 		$declaration = array_merge(
 			...array_map(
-				static function ( string $item, string $property ) use ( $isImportant ): array {
+				static function ( string $item, string $property ): array {
 
-					return [ "padding-{$property}" => blockera_get_value_addon_real_value( $item ) . $isImportant ];
+					return [ "padding-{$property}" => blockera_get_value_addon_real_value( $item ) ];
 				},
 				$padding,
 				array_keys( $padding )
 			),
 			...array_map(
-				static function ( string $item, string $property ) use ( $isImportant ): array {
+				static function ( string $item, string $property ): array {
 
-					return [ "margin-{$property}" => blockera_get_value_addon_real_value( $item ) . $isImportant ];
+					return [ "margin-{$property}" => blockera_get_value_addon_real_value( $item ) ];
 				},
 				$margin,
 				array_keys( $margin )

--- a/packages/editor/php/StyleDefinitions/Typography.php
+++ b/packages/editor/php/StyleDefinitions/Typography.php
@@ -44,25 +44,25 @@ class Typography extends BaseStyleDefinition {
 			case 'text-orientation':
 				switch ( $propertyValue ) {
 					case 'style-1':
-						$declaration['writing-mode']     = 'vertical-lr' . $this->getImportant();
-						$declaration['text-orientation'] = 'mixed' . $this->getImportant();
+						$declaration['writing-mode']     = 'vertical-lr';
+						$declaration['text-orientation'] = 'mixed';
 						break;
 					case 'style-2':
-						$declaration['writing-mode']     = 'vertical-rl' . $this->getImportant();
-						$declaration['text-orientation'] = 'mixed' . $this->getImportant();
+						$declaration['writing-mode']     = 'vertical-rl';
+						$declaration['text-orientation'] = 'mixed';
 						break;
 					case 'style-3':
-						$declaration['writing-mode']     = 'vertical-lr' . $this->getImportant();
-						$declaration['text-orientation'] = 'upright' . $this->getImportant();
+						$declaration['writing-mode']     = 'vertical-lr';
+						$declaration['text-orientation'] = 'upright';
 						break;
 					case 'style-4':
-						$declaration['writing-mode']     = 'vertical-rl' . $this->getImportant();
-						$declaration['text-orientation'] = 'upright' . $this->getImportant();
+						$declaration['writing-mode']     = 'vertical-rl';
+						$declaration['text-orientation'] = 'upright';
 						break;
 					case 'initial':
 						$declaration['writing-mode']     =
-							'horizontal-tb' . $this->getImportant();
-						$declaration['text-orientation'] = 'mixed' . $this->getImportant();
+							'horizontal-tb';
+						$declaration['text-orientation'] = 'mixed';
 				}
 				break;
 

--- a/packages/editor/php/helpers.php
+++ b/packages/editor/php/helpers.php
@@ -387,9 +387,11 @@ if ( ! function_exists( 'blockera_get_compatible_block_css_selector' ) ) {
 		// Rewrite block type selectors because we provide suitable selectors array of original array.
 		$cloned_block_type->selectors = $selectors;
 
-		$selector = wp_get_block_css_selector( $cloned_block_type, $feature_id );
+		$has_fallback = ! empty( $args['fallback'] );
 
-		if ( ! $selector && ! empty( $args['fallback'] ) ) {
+		$selector = wp_get_block_css_selector( $cloned_block_type, $feature_id, ! $has_fallback );
+
+		if ( ! $selector && $has_fallback ) {
 
 			$selector = wp_get_block_css_selector( $cloned_block_type, $args['fallback'], true );
 		}
@@ -423,8 +425,6 @@ if ( ! function_exists( 'blockera_append_root_block_css_selector' ) ) {
 	 * @return string the combined block prepared css selector with root.
 	 */
 	function blockera_append_root_block_css_selector( string $selector, string $root, array $args = [] ): string {
-
-		$root = preg_replace( '/:\w+/i', '', $root );
 
 		// Assume recieved selector is invalid.
 		if ( empty( trim( $selector ) ) ) {

--- a/packages/editor/php/helpers.php
+++ b/packages/editor/php/helpers.php
@@ -398,9 +398,9 @@ if ( ! function_exists( 'blockera_get_compatible_block_css_selector' ) ) {
 
 		// We not needs append blockera root block css selector into inners selector.
 		// Like => current $selector value is one of feature id of "elements/link" inner block selectors.
-		if ( ! $feature_id || str_starts_with( $feature_id, 'blockera/' ) ) {
+		if ( ! $feature_id || str_starts_with( $feature_id, 'blockera/' ) || empty( $selectors['fallback'] ) ) {
 
-			return $selector ?? $selectors['fallback'];
+			return $selector ?? $selectors['fallback'] ?? '';
 		}
 
 		return blockera_append_root_block_css_selector(

--- a/packages/editor/php/tests/Fixtures/StyleEngine/block-state-selectors.php
+++ b/packages/editor/php/tests/Fixtures/StyleEngine/block-state-selectors.php
@@ -2,6 +2,7 @@
 
 return [
 	[
+		// It Should retrieve selectors array with just fallback item because original block selectors array is empty!
 		[
 			'block-settings'     => [],
 			'is-inner-block'     => false,
@@ -16,6 +17,7 @@ return [
 		],
 	],
 	[
+		// It Should retrieve selectors array include merged fallback item with original block selectors array.
 		[
 			'block-settings'     => [],
 			'is-inner-block'     => false,
@@ -41,6 +43,7 @@ return [
 		],
 	],
 	[
+		// It Should retrieve selectors array with appending pseudo-class as suffix to "elements/link" selectors.
 		[
 			'block-settings'     => [],
 			'is-inner-block'     => true,
@@ -72,6 +75,7 @@ return [
 		],
 	],
 	[
+		// It Should retrieve selectors array with merged fallback item with original block selectors array.
 		[
 			'block-settings'     => [],
 			'is-inner-block'     => false,

--- a/packages/editor/php/tests/Fixtures/StyleEngine/calculation-css-selector.php
+++ b/packages/editor/php/tests/Fixtures/StyleEngine/calculation-css-selector.php
@@ -7,11 +7,11 @@ return [
 		'fallbackId' => '',
 		'expected'   => '.blockera-block.blockera-block--phggmy.wp-block-sample, .blockera-block.blockera-block--phggmy.wp-block-sample .first-child, .blockera-block.blockera-block--phggmy.wp-block-sample .second-child, .wp-block-sample.blockera-block.blockera-block--phggmy, .wp-block-sample.blockera-block.blockera-block--phggmy .first-child, .wp-block-sample.blockera-block.blockera-block--phggmy .second-child',
 	],
-	// It should retrieve fallback selector of "core/sample" block type.
+	// It should retrieve root selector of "core/sample" block while feature identify is invalid.
 	[
 		'featureId'  => 'invalid-feature-id',
 		'fallbackId' => '',
-		'expected'   => '.blockera-block.blockera-block--phggmy',
+		'expected'   => '.blockera-block.blockera-block--phggmy.wp-block-sample, .blockera-block.blockera-block--phggmy.wp-block-sample .first-child, .blockera-block.blockera-block--phggmy.wp-block-sample .second-child, .wp-block-sample.blockera-block.blockera-block--phggmy, .wp-block-sample.blockera-block.blockera-block--phggmy .first-child, .wp-block-sample.blockera-block.blockera-block--phggmy .second-child',
 	],
 	// It should retrieve root selector of "core/sample" block but rewrite root selector with blockera unique selector for block type.
 	[

--- a/packages/editor/php/tests/Fixtures/StyleEngine/calculation-css-selector.php
+++ b/packages/editor/php/tests/Fixtures/StyleEngine/calculation-css-selector.php
@@ -1,38 +1,28 @@
 <?php
 
 return [
+	// It should retrieve root selector of "core/sample" block but rewrite root selector with blockera unique selector for block type.
 	[
-		'selectors' => [
-			'root' => '.a',
-		],
-		'featureId' => 'invalid-feature-id',
+		'featureId'  => 'root',
 		'fallbackId' => '',
-		'expected'  => '.a',
+		'expected'   => '.blockera-block.blockera-block--phggmy.wp-block-sample, .blockera-block.blockera-block--phggmy.wp-block-sample .first-child, .blockera-block.blockera-block--phggmy.wp-block-sample .second-child, .wp-block-sample.blockera-block.blockera-block--phggmy, .wp-block-sample.blockera-block.blockera-block--phggmy .first-child, .wp-block-sample.blockera-block.blockera-block--phggmy .second-child',
 	],
+	// It should retrieve fallback selector of "core/sample" block type.
 	[
-		'selectors' => [],
-		'featureId' => 'invalid-feature-id',
+		'featureId'  => 'invalid-feature-id',
 		'fallbackId' => '',
-		'expected'  => '',
+		'expected'   => '.blockera-block.blockera-block--phggmy',
 	],
+	// It should retrieve root selector of "core/sample" block but rewrite root selector with blockera unique selector for block type.
 	[
-		'selectors' => [
-			'dimensions' => [
-				'aspectRatio' => '.a',
-			],
-		],
-		'featureId' => 'aspect-ratio',
-		'fallbackId' => 'dimensions.aspectRatio',
-		'expected'  => '.a',
+		'featureId'  => 'blockera/elements/link',
+		'fallbackId' => '',
+		'expected'   => 'a:not(.wp-element-button)',
 	],
+	// It should retrieve root selector of "blockera/elements/link" of "core/sample" block but rewrite root selector with blockera unique selector for block type.
 	[
-		'selectors' => [
-			'dimensions' => [
-				'aspectRatio' => '.a',
-			],
-		],
-		'featureId' => 'aspect-ratio',
-		'fallbackId' => 'dimensions.aspectRatio',
-		'expected'  => '.a',
+		'featureId'  => 'blockeraWidth',
+		'fallbackId' => [ 'blockera/elements/link', 'width' ],
+		'expected'   => '.blockera-block.blockera-block--phggmy.wp-block-sample a, .wp-block-sample.blockera-block.blockera-block--phggmy a',
 	],
 ];

--- a/packages/wordpress/php/functions.php
+++ b/packages/wordpress/php/functions.php
@@ -1,5 +1,20 @@
 <?php
 
+if ( ! function_exists( 'blockera_get_block_type' ) ) {
+
+	/**
+	 * Get WordPress block type instance by name.
+	 *
+	 * @param string $name The block type name.
+	 *
+	 * @return WP_Block_Type | null The WP_Block_Type instance object.
+	 */
+	function blockera_get_block_type( string $name ): ?WP_Block_Type {
+
+		return WP_Block_Type_Registry::get_instance()->get_registered( $name );
+	}
+}
+
 if ( ! function_exists( 'blockera_get_block_type_property' ) ) {
 
 	/**
@@ -12,7 +27,7 @@ if ( ! function_exists( 'blockera_get_block_type_property' ) ) {
 	 */
 	function blockera_get_block_type_property( string $name, string $property_name ) {
 
-		$registered = WP_Block_Type_Registry::get_instance()->get_registered( $name );
+		$registered = blockera_get_block_type( $name );
 
 		if ( null === $registered || ! property_exists( $registered, $property_name ) ) {
 


### PR DESCRIPTION
  ## What?
  We needs to compatible way to access blocks css selector with WordPress Gutenberg editor. In this PR I tried to implements functionalities for access to block css selector on editor and front end sides.
  
  ## Tasks

- [x] use getBlockCSSSelector() private api of @wordpress/block-editor package into blockera style-engine as cloned function of WordPress/gutenberg repository.
- [x]  use wp_get_block_css_selector() api of WordPress PHP script inside blockera repository to access blocks compatible css selector with WordPress style engine.
- [x] pass all tests
  