### PR TITLE
Add css media query support into JavaScript style engine and refactor canvas editor interacts with Editor Iframe

### DIFF
--- a/packages/editor/js/canvas-editor/bootstrap.js
+++ b/packages/editor/js/canvas-editor/bootstrap.js
@@ -24,8 +24,8 @@ import type { GetTarget } from './types';
 
 // Compatibility for WordPress supported versions.
 const getTarget = (version: string): GetTarget => {
-	// For WordPress version equals or bigger than 6.6 version.
-	if (Number(version?.replace(/\./g, '')) >= 66) {
+	// For WordPress version equals or bigger than 6.6.1 version.
+	if (Number(version?.replace(/\./g, '')) >= 661) {
 		return {
 			header: '.editor-header__center',
 			previewDropdown: '.editor-preview-dropdown',
@@ -33,11 +33,13 @@ const getTarget = (version: string): GetTarget => {
 		};
 	}
 
-	// For less than WordPress 6.6 versions.
+	// For less than WordPress 6.6.1 versions.
 	return {
-		header: '.edit-post-header__center',
+		header: isLoadedSiteEditor()
+			? '.edit-site-header-edit-mode__center'
+			: '.edit-post-header__center',
 		postPreviewElement: 'a[aria-label="View Post"]',
-		previewDropdown: 'div.block-editor-post-preview__dropdown',
+		previewDropdown: 'div.edit-site-header-edit-mode__preview-options',
 	};
 };
 

--- a/packages/editor/js/canvas-editor/components/breakpoints/index.js
+++ b/packages/editor/js/canvas-editor/components/breakpoints/index.js
@@ -11,8 +11,6 @@ import { useEffect, useState } from '@wordpress/element';
 /**
  * Blockera dependencies
  */
-import { getIframe, getIframeTag, isEquals } from '@blockera/utils';
-import { controlInnerClassNames } from '@blockera/classnames';
 import {
 	Flex,
 	Popover,
@@ -21,6 +19,8 @@ import {
 } from '@blockera/controls';
 import { Icon } from '@blockera/icons';
 import { experimental } from '@blockera/env';
+import { controlInnerClassNames } from '@blockera/classnames';
+import { isEquals, getIframe, getIframeTag } from '@blockera/utils';
 
 /**
  * Internal dependencies
@@ -66,7 +66,6 @@ export const Breakpoints = ({
 	const breakpoints = getBreakpoints();
 
 	useEffect(() => {
-		let inIframe = false;
 		let editorWrapper: Object = document.querySelector(
 			'.editor-styles-wrapper'
 		);
@@ -77,8 +76,6 @@ export const Breakpoints = ({
 			if (!editorWrapper) {
 				return;
 			}
-
-			inIframe = true;
 		}
 
 		const {
@@ -90,34 +87,27 @@ export const Breakpoints = ({
 			editorWrapper.classList.add('blockera-canvas');
 		}
 
-		if (isBaseBreakpoint(deviceType)) {
-			if (!editorWrapper.classList.contains('preview-margin')) {
-				if (editorWrapper.parentElement) {
-					editorWrapper.parentElement.style.background = '#222222';
-				}
-			} else {
-				editorWrapper.style.minWidth = '100%';
-				editorWrapper.style.maxWidth = '100%';
-				editorWrapper.classList.remove('preview-margin');
+		// We try to clean up additional styles added from our custom breakpoints (means: any breakpoints apart from 'desktop', 'tablet', and 'mobile')
+		// of iframe and editor styles wrapper elements of post|site editor.
+		if (
+			isBaseBreakpoint(deviceType) &&
+			editorWrapper.classList.contains('preview-margin')
+		) {
+			editorWrapper.style.minWidth = '100%';
+			editorWrapper.style.maxWidth = '100%';
+			editorWrapper.style.removeProperty('margin');
+			editorWrapper.classList.remove('preview-margin');
+			editorWrapper.parentElement.style.removeProperty('background');
 
-				// Assume user working with canvas editor on site editor!
-				if (inIframe) {
-					editorWrapper.style.removeProperty('margin');
-				}
-
-				if (iframe) {
-					iframe.style.removeProperty('min-width');
-					iframe.style.removeProperty('max-width');
-					iframe.parentElement.style.removeProperty('background');
-				}
-
-				if (editorWrapper.parentElement) {
-					editorWrapper.parentElement.style.removeProperty(
-						'background'
-					);
-				}
+			if (iframe) {
+				iframe.style.removeProperty('min-width');
+				iframe.style.removeProperty('max-width');
+				iframe.parentElement.style.removeProperty('background');
 			}
-		} else {
+		}
+		// We try to set our custom breakpoints (means: any breakpoints apart from 'desktop', 'tablet', and 'mobile') settings into,
+		// iframe element as dimensions with preview margin style.
+		else if (!['desktop', 'tablet', 'mobile'].includes(deviceType)) {
 			if (iframe) {
 				if (min && max) {
 					iframe.style.minWidth = min;
@@ -127,17 +117,10 @@ export const Breakpoints = ({
 				} else if (max) {
 					iframe.style.maxWidth = max;
 				}
-
-				iframe.parentElement.style.background = '#222222';
 			}
 
 			if (!editorWrapper.classList.contains('preview-margin')) {
 				editorWrapper.classList.add('preview-margin');
-
-				// Assume user working with canvas editor on site editor!
-				if (inIframe) {
-					editorWrapper.style.margin = '72px auto';
-				}
 			}
 		}
 

--- a/packages/editor/js/canvas-editor/components/breakpoints/picked-breakpoints.js
+++ b/packages/editor/js/canvas-editor/components/breakpoints/picked-breakpoints.js
@@ -4,8 +4,8 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { select } from '@wordpress/data';
 import type { MixedElement } from 'react';
+import { select, dispatch } from '@wordpress/data';
 import { useState, useEffect } from '@wordpress/element';
 
 /**
@@ -24,11 +24,14 @@ import type {
 	TBreakpoint,
 	BreakpointTypes,
 } from '../../../extensions/libs/block-states/types';
+import { pascalCase } from '@blockera/utils';
 
 export default function ({
 	onClick,
 	updaterDeviceIndicator,
 }: PickedBreakpointsComponentProps): MixedElement {
+	const { __experimentalSetPreviewDeviceType } =
+		dispatch('core/edit-post') || {};
 	const { getBreakpoints } = select('blockera/editor');
 	const availableBreakpoints: { [key: TBreakpoint]: BreakpointTypes } =
 		getBreakpoints();
@@ -61,6 +64,21 @@ export default function ({
 								if (itemId !== currentActiveBreakpoint) {
 									onClick(itemId);
 									setActiveBreakpoint(itemId);
+
+									// TODO: in this on click handler we need to do set other breakpoints as "previewDeviceType" in future like available breakpoints on WordPress,
+									// because WordPress is not support our all breakpoints.
+									// We should update WordPress "edit-post" store state for "previewDeviceType" property,
+									// because if registered one block type with apiVersion < 3, block-editor try to rendering blocks out of iframe element,
+									// so we need to set "previewDeviceType" to rendering blocks inside iframe element and we inject css generated style into iframe,
+									// for responsive reasons.
+									if (
+										'function' ===
+										typeof __experimentalSetPreviewDeviceType
+									) {
+										__experimentalSetPreviewDeviceType(
+											pascalCase(itemId)
+										);
+									}
 								}
 							}}
 						/>

--- a/packages/editor/js/canvas-editor/components/breakpoints/picked-breakpoints.js
+++ b/packages/editor/js/canvas-editor/components/breakpoints/picked-breakpoints.js
@@ -31,7 +31,7 @@ export default function ({
 	updaterDeviceIndicator,
 }: PickedBreakpointsComponentProps): MixedElement {
 	const { __experimentalSetPreviewDeviceType } =
-		dispatch('core/edit-post') || {};
+		dispatch('core/edit-post') || dispatch('core/edit-site') || {};
 	const { getBreakpoints } = select('blockera/editor');
 	const availableBreakpoints: { [key: TBreakpoint]: BreakpointTypes } =
 		getBreakpoints();

--- a/packages/editor/js/canvas-editor/style.scss
+++ b/packages/editor/js/canvas-editor/style.scss
@@ -177,7 +177,11 @@
 	}
 }
 
-.editor-header__center {
+// Compatible with WordPress 6.5.2 - 6.6.1 versions.
+
+.editor-header__center,
+ .edit-post-header__center,
+ .edit-site-header-edit-mode__center {
 	gap: 10px;
 	align-items: center;
 

--- a/packages/editor/js/canvas-editor/test/canvas-editor.e2e.cy.js
+++ b/packages/editor/js/canvas-editor/test/canvas-editor.e2e.cy.js
@@ -55,8 +55,11 @@ describe('Canvas editor testing', () => {
 			force: true,
 		});
 
-		cy.getIframeBody().find('main').click({ force: true });
-
-		cy.getByDataTest('blockera-canvas-editor').should('exist');
+		cy.getIframeBody()
+			.find('main')
+			.click({ force: true })
+			.then(() => {
+				cy.getByDataTest('blockera-canvas-editor').should('exist');
+			});
 	});
 });

--- a/packages/editor/js/canvas-editor/test/canvas-editor.e2e.cy.js
+++ b/packages/editor/js/canvas-editor/test/canvas-editor.e2e.cy.js
@@ -51,7 +51,9 @@ describe('Canvas editor testing', () => {
 		cy.getByDataTest('blockera-canvas-editor').should('exist');
 
 		// We should use selector, because not founded any other data attribute for WordPress view mode toggle button.
-		cy.get('button.edit-site-layout__view-mode-toggle').click();
+		cy.get('button.edit-site-layout__view-mode-toggle').click({
+			force: true,
+		});
 
 		cy.getIframeBody().find('main').click({ force: true });
 

--- a/packages/editor/js/style-engine/components/block-style.js
+++ b/packages/editor/js/style-engine/components/block-style.js
@@ -9,10 +9,7 @@ import type { MixedElement } from 'react';
  * Internal dependencies
  */
 import type { BlockStyleProps } from './types';
-import {
-	// MediaQuery,
-	StateStyle,
-} from '../';
+import { StateStyle } from '../';
 import { useExtensionsStore } from '../../hooks/use-extensions-store';
 
 export const BlockStyle = (props: BlockStyleProps): MixedElement => {
@@ -34,7 +31,6 @@ export const BlockStyle = (props: BlockStyleProps): MixedElement => {
 
 	return (
 		<style>
-			{/*<MediaQuery breakpoint={currentBreakpoint}>*/}
 			<StateStyle
 				{...{
 					...props,
@@ -46,7 +42,6 @@ export const BlockStyle = (props: BlockStyleProps): MixedElement => {
 					styleEngineConfig: props.supports?.blockeraStyleEngine,
 				}}
 			/>
-			{/*</MediaQuery>*/}
 		</style>
 	);
 };

--- a/packages/editor/js/style-engine/components/index.js
+++ b/packages/editor/js/style-engine/components/index.js
@@ -1,6 +1,7 @@
 // @flow
 
 export * from './style';
+export * from './media-query';
 export * from './block-style';
 export * from './state-style';
 export * from './styles-wrapper';

--- a/packages/editor/js/style-engine/components/media-query.js
+++ b/packages/editor/js/style-engine/components/media-query.js
@@ -1,0 +1,38 @@
+// @flow
+
+/**
+ * External dependencies
+ */
+import type { Element } from 'react';
+
+/**
+ * Blockera dependencies
+ */
+import { useMedia } from '../hooks';
+
+/**
+ * Internal dependencies
+ */
+import type { MediaQueryProps } from './types';
+import { isBaseBreakpoint } from '../../canvas-editor/components/breakpoints/helpers';
+
+export const MediaQuery = ({
+	breakpoint,
+	children,
+}: MediaQueryProps): Element<any> => {
+	const { [breakpoint]: media } = useMedia();
+
+	return (
+		<>
+			{isBaseBreakpoint(breakpoint) && children}
+			{media && (
+				<>
+					{media}
+					{'{'}
+					{children}
+					{'}'}
+				</>
+			)}
+		</>
+	);
+};

--- a/packages/editor/js/style-engine/get-compatible-block-css-selector.js
+++ b/packages/editor/js/style-engine/get-compatible-block-css-selector.js
@@ -17,7 +17,6 @@ import type { InnerBlockType } from '../extensions/libs/inner-blocks/types';
  * Internal dependencies
  */
 import { replaceVariablesValue } from './utils';
-import { getBaseBreakpoint } from '../canvas-editor';
 import type { NormalizedSelectorProps } from './types';
 import { isNormalState } from '../extensions/components';
 import { getBlockCSSSelector } from './get-block-css-selector';
@@ -34,18 +33,9 @@ export const getCompatibleBlockCssSelector = ({
 	blockSelectors,
 	className = '',
 	suffixClass = '',
-	activeDeviceType,
 	fallbackSupportId,
-	device = getBaseBreakpoint(),
 }: NormalizedSelectorProps): string => {
-	let rootSelector =
-		getBaseBreakpoint() === device
-			? '{{BLOCK_ID}}'
-			: `.is-${device}-preview {{BLOCK_ID}}`;
-
-	if (device === activeDeviceType && getBaseBreakpoint() !== device) {
-		rootSelector = `.is-${device}-preview {{BLOCK_ID}}`;
-	}
+	const rootSelector = '{{BLOCK_ID}}';
 
 	const selectors: {
 		[key: TStates]: {

--- a/packages/editor/js/style-engine/hooks/index.js
+++ b/packages/editor/js/style-engine/hooks/index.js
@@ -1,3 +1,4 @@
 // @flow
 
+export { useMedia } from './use-media';
 export { useComputedCssProps } from './use-computed-css-props';

--- a/packages/editor/js/style-engine/hooks/use-computed-css-props.js
+++ b/packages/editor/js/style-engine/hooks/use-computed-css-props.js
@@ -77,6 +77,47 @@ export const useComputedCssProps = ({
 		return state?.isVisible && !!state?.breakpoints;
 	};
 
+	const generateCssStyleForInnerBlocksInPseudoStates = ({
+		blockType,
+		attributes,
+		masterState,
+	}: Object) => {
+		for (const stateType in attributes?.blockeraBlockStates || {}) {
+			const stateItem = attributes?.blockeraBlockStates[stateType];
+
+			if (!validateBlockStates(stateItem)) {
+				continue;
+			}
+
+			const breakpoints = stateItem.breakpoints;
+
+			for (const breakpointType in breakpoints) {
+				if (breakpointType !== currentBreakpoint) {
+					continue;
+				}
+
+				const breakpointItem = breakpoints[breakpointType];
+
+				if (!Object.keys(breakpointItem?.attributes || {}).length) {
+					continue;
+				}
+
+				appendStyles({
+					...calculatedProps,
+					state: stateType,
+					masterState,
+					selectors: selectors[appendBlockeraPrefix(blockType)] || {},
+					attributes: {
+						...defaultAttributes,
+						...breakpointItem?.attributes,
+					},
+					currentBlock: blockType,
+					device: breakpointType,
+				});
+			}
+		}
+	};
+
 	const generateCssStyleForInnerBlocks = (
 		[blockType, { attributes }]: [InnerBlockType | string, Object],
 		device: TBreakpoint | string,
@@ -86,6 +127,12 @@ export const useComputedCssProps = ({
 		if (!Object.keys(attributes).length) {
 			return;
 		}
+
+		generateCssStyleForInnerBlocksInPseudoStates({
+			blockType,
+			attributes,
+			masterState,
+		});
 
 		appendStyles({
 			...calculatedProps,
@@ -165,54 +212,6 @@ export const useComputedCssProps = ({
 				);
 			}
 		}
-
-		Object.entries(params?.attributes?.blockeraInnerBlocks).forEach(
-			([blockType, { attributes }]: [
-				InnerBlockType | string,
-				Object
-			]): void => {
-				for (const stateType in attributes?.blockeraBlockStates || {}) {
-					const stateItem =
-						attributes?.blockeraBlockStates[stateType];
-
-					if (!validateBlockStates(stateItem)) {
-						continue;
-					}
-
-					const breakpoints = stateItem.breakpoints;
-
-					for (const breakpointType in breakpoints) {
-						if (breakpointType !== currentBreakpoint) {
-							continue;
-						}
-
-						const breakpointItem = breakpoints[breakpointType];
-
-						if (
-							!Object.keys(breakpointItem?.attributes || {})
-								.length
-						) {
-							continue;
-						}
-
-						appendStyles({
-							...calculatedProps,
-							state: stateType,
-							masterState: 'normal',
-							selectors:
-								selectors[appendBlockeraPrefix(blockType)] ||
-								{},
-							attributes: {
-								...defaultAttributes,
-								...breakpointItem?.attributes,
-							},
-							currentBlock: blockType,
-							device: breakpointType,
-						});
-					}
-				}
-			}
-		);
 	}
 
 	return stylesStack.flat();

--- a/packages/editor/js/style-engine/hooks/use-media.js
+++ b/packages/editor/js/style-engine/hooks/use-media.js
@@ -1,0 +1,31 @@
+// @flow
+
+/**
+ * Blockera dependencies
+ */
+import type { BreakpointTypes } from '@blockera/editor/js/extensions/libs/block-states/types';
+import breakpoints from '@blockera/editor/js/extensions/libs/block-states/default-breakpoints';
+
+export const useMedia = (): { [key: string]: string } => {
+	const medias: { [key: string]: string } = {};
+
+	Object.values(breakpoints()).forEach(
+		({ type, settings }: BreakpointTypes): void => {
+			const { min, max } = settings;
+
+			let media = '';
+
+			if (min && max) {
+				media = `@media screen and (max-width: ${max}) and (min-width: ${min})`;
+			} else if (min) {
+				media = `@media screen and (min-width: ${min})`;
+			} else if (max) {
+				media = `@media screen and (max-width: ${max})`;
+			}
+
+			medias[type] = media;
+		}
+	);
+
+	return medias;
+};

--- a/packages/utils/js/get/index.js
+++ b/packages/utils/js/get/index.js
@@ -16,17 +16,23 @@
 // };
 
 /**
- * Retrieve iframe content tag element with css selector.
- *
- * @param {string} selector the css selector.
+ * Retrieve iframe content dom element.
  *
  * @return {HTMLElement|void} the iframe content document body element.
  */
+export const getIframe = (): HTMLElement | void => {
+	// $FlowFixMe
+	return document.querySelector('iframe[name="editor-canvas"]');
+};
+
+/**
+ * Retrieve iframe content tag dom element with css selector.
+ *
+ * @param {string} selector the css selector.
+ *
+ * @return {HTMLElement|void} the founded dom element of iframe.
+ */
 export const getIframeTag = (selector: string): HTMLElement | void => {
-	return (
-		document
-			.querySelector('iframe[name="editor-canvas"]')
-			// $FlowFixMe
-			?.contentDocument?.querySelector(selector)
-	);
+	// $FlowFixMe
+	return getIframe()?.contentDocument?.querySelector(selector);
 };


### PR DESCRIPTION
Refactor client style engine to support css media queries.

## Tasks

- [x] Fix canvas editor compatibility with WordPress blocks of apiVersion less than 3.  in apiVersion 2 block types rendering outside of iframe while in apiVersion 3 rendering block types inside iframe element to solve responsive problems.
- [x] Refactor style engine like php script to handling css media queries to support style inheritance between breakpoints.
- [x] write new tests to checking iframe element rendering.