### PR TITLE
Update WordPress 'Tested up to' version to 6.6

### DIFF
--- a/blockera.php
+++ b/blockera.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://blockera.ai/blockera-page-builder/
  * Description: The Advanced Mode for Gutenberg
  * Requires at least: 6.6
- * Tested up to: 6.5.2
+ * Tested up to: 6.6
  * Requires PHP: 7.4
  * Author: Blockera AI
  * Author URI: https://blockera.ai/about-us/


### PR DESCRIPTION
Error: Tested up to: 6.5.2 < 6.6. The "Tested up to" value in your plugin is not set to the current version of WordPress. This means your plugin will not show up in searches, as we require plugins to be compatible and documented as tested up to the most recent version of WordPress.