### PR TITLE
Bug: Group block variation control bug with updating `Layout Section → Flex Layout` control

### DIFF
--- a/packages/blocks/core/CHANGELOG.md
+++ b/packages/blocks/core/CHANGELOG.md
@@ -1,1 +1,9 @@
 ## Unreleased
+
+### Bug Fixes
+
+- Fixed an issue with test assertions.
+
+### Miscellaneous
+
+- Updated the changelog for the blockera/blocks-core package.

--- a/packages/blocks/core/js/wordpress/group/test/variation-switch.compatibility.e2e.cy.js
+++ b/packages/blocks/core/js/wordpress/group/test/variation-switch.compatibility.e2e.cy.js
@@ -90,6 +90,22 @@ describe('Group Block → Variation Switch Compatibility', () => {
 			);
 		});
 
+		cy.getParentContainer('Display')
+			.first()
+			.within(() => {
+				cy.getByAriaLabel('Flex')
+					.invoke('attr', 'aria-pressed')
+					.should('eq', 'true');
+			});
+
+		cy.getParentContainer('Flex Layout')
+			.first()
+			.within(() => {
+				cy.getByAriaLabel('Row')
+					.invoke('attr', 'aria-checked')
+					.should('eq', 'true');
+			});
+
 		//
 		// Test 3: Change Variation to `group-stack`
 		//
@@ -115,6 +131,22 @@ describe('Group Block → Variation Switch Compatibility', () => {
 				getSelectedBlock(data, 'blockeraFlexLayout')?.alignItems
 			);
 		});
+
+		cy.getParentContainer('Display')
+			.first()
+			.within(() => {
+				cy.getByAriaLabel('Flex')
+					.invoke('attr', 'aria-pressed')
+					.should('eq', 'true');
+			});
+
+		cy.getParentContainer('Flex Layout')
+			.first()
+			.within(() => {
+				cy.getByAriaLabel('Column')
+					.invoke('attr', 'aria-checked')
+					.should('eq', 'true');
+			});
 
 		//
 		// Test 4: Change Variation to `group-grid`
@@ -143,6 +175,14 @@ describe('Group Block → Variation Switch Compatibility', () => {
 			);
 		});
 
+		cy.getParentContainer('Display')
+			.first()
+			.within(() => {
+				cy.getByAriaLabel('Grid')
+					.invoke('attr', 'aria-pressed')
+					.should('eq', 'true');
+			});
+
 		//
 		// Test 5: Change Variation to `group`
 		//
@@ -169,6 +209,18 @@ describe('Group Block → Variation Switch Compatibility', () => {
 				getSelectedBlock(data, 'blockeraFlexLayout')?.alignItems
 			);
 		});
+
+		cy.getParentContainer('Display')
+			.first()
+			.within(() => {
+				cy.getByAriaLabel('Grid')
+					.invoke('attr', 'aria-pressed')
+					.should('eq', false);
+
+				cy.getByAriaLabel('Flex')
+					.invoke('attr', 'aria-pressed')
+					.should('eq', false);
+			});
 	});
 
 	it('Variation Switch (`To WP` Compatibility)', () => {

--- a/packages/blocks/core/js/wordpress/group/test/variation-switch.compatibility.e2e.cy.js
+++ b/packages/blocks/core/js/wordpress/group/test/variation-switch.compatibility.e2e.cy.js
@@ -215,11 +215,11 @@ describe('Group Block → Variation Switch Compatibility', () => {
 			.within(() => {
 				cy.getByAriaLabel('Grid')
 					.invoke('attr', 'aria-pressed')
-					.should('eq', false);
+					.should('eq', 'false');
 
 				cy.getByAriaLabel('Flex')
 					.invoke('attr', 'aria-pressed')
-					.should('eq', false);
+					.should('eq', 'false');
 			});
 	});
 

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -6,7 +6,15 @@
 - JS error while resetting the gap feature [[🔗 Bug](https://community.blockera.ai/bugs-mdhyb8nc/post/js-error-while-resetting-the-gap-feature-DMkePSiXbnwyPSE)]
 - CSS Display property always should be printed to prevent bugs [[🔗 Bug](https://community.blockera.ai/bugs-mdhyb8nc/post/display-feature-always-not-priting-aKA5Jr0gnb6N6Yu)]
 - Flex layout align items and justify content not working properly for column direction [[🔗 Bug](https://community.blockera.ai/bugs-mdhyb8nc/post/flex-layout-bug-aZ0Z3LqgOT8aApK)]
+- Text align feature change from block toolbar not update Typography block section control [[🔗 Bug](https://community.blockera.ai/bugs-mdhyb8nc/post/changing-text-aling-not-affects-inside-blockera-typography-section-kjKfo0aGpFIJSre)]
+- Heading block text align compatibility 
+- Layout Section → Flex Child → Self order icon is wrong [[🔗 Bug](https://community.blockera.ai/bugs-mdhyb8nc/post/flex-chlild-order-icon-is-wrong-uVCroH9QzuZSWsf)]
+- Extra Blockera logo is showing in blocks preview section [[🔗 Bug](https://community.blockera.ai/bugs-mdhyb8nc/post/extra-logo-on-blocks-fFacaGcdbdRHS3M)]
+- Strange "0" character after Layout block section [[🔗 Bug](https://community.blockera.ai/bugs-mdhyb8nc/post/strange-0-after-layout-block-section-tXhcZXMGMn631EH)]
+- Strange bug of flex layout that makes issue for inner blocks flex layout.
+- Wrong style generation for blocks in gap feature [[🔗 Bug](https://community.blockera.ai/bugs-mdhyb8nc/post/wrong-style-generation-for-blocks-in-gap-feature-nkRSbYvjaK226Rh)]
 
 ### Improvements
 
+- Design of post preview link in header improved.
 - Refactored BlockBase component to fix compatibility with WordPress problems.

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -6,3 +6,7 @@
 - JS error while resetting the gap feature [[🔗 Bug](https://community.blockera.ai/bugs-mdhyb8nc/post/js-error-while-resetting-the-gap-feature-DMkePSiXbnwyPSE)]
 - CSS Display property always should be printed to prevent bugs [[🔗 Bug](https://community.blockera.ai/bugs-mdhyb8nc/post/display-feature-always-not-priting-aKA5Jr0gnb6N6Yu)]
 - Flex layout align items and justify content not working properly for column direction [[🔗 Bug](https://community.blockera.ai/bugs-mdhyb8nc/post/flex-layout-bug-aZ0Z3LqgOT8aApK)]
+
+### Improvements
+
+- Refactored BlockBase component to fix compatibility with WordPress problems.

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -13,8 +13,8 @@
 - Strange "0" character after Layout block section [[🔗 Bug](https://community.blockera.ai/bugs-mdhyb8nc/post/strange-0-after-layout-block-section-tXhcZXMGMn631EH)]
 - Strange bug of flex layout that makes issue for inner blocks flex layout.
 - Wrong style generation for blocks in gap feature [[🔗 Bug](https://community.blockera.ai/bugs-mdhyb8nc/post/wrong-style-generation-for-blocks-in-gap-feature-nkRSbYvjaK226Rh)]
+- Refactored BlockBase component to fix compatibility with WordPress problems. [[🔗 Bug](https://community.blockera.ai/bugs-mdhyb8nc/post/group-block-variation-control-bug-with-updating-layout-section---flex-MSd1lhFdxAGDd2c)]
 
 ### Improvements
 
 - Design of post preview link in header improved.
-- Refactored BlockBase component to fix compatibility with WordPress problems.

--- a/packages/editor/js/extensions/components/block-base.js
+++ b/packages/editor/js/extensions/components/block-base.js
@@ -110,29 +110,22 @@ export const BlockBase: ComponentType<BlockBaseProps> = memo(
 			currentInnerBlockState,
 		} = useExtensionsStore({ name, clientId });
 
-		const {
-			selectedBlock,
-			activeVariation,
-			availableAttributes,
-			isActiveBlockExtensions,
-		} = useSelect((select) => {
-			const { isActiveBlockExtensions, getActiveBlockVariation } = select(
-				'blockera/extensions'
-			);
+		const { availableAttributes, isActiveBlockExtensions } = useSelect(
+			(select) => {
+				const { isActiveBlockExtensions, getActiveBlockVariation } =
+					select('blockera/extensions');
 
-			const { getBlockType } = select('core/blocks');
-			const { getSelectedBlock } = select('core/block-editor');
+				const { getBlockType } = select('core/blocks');
+				const { getSelectedBlock } = select('core/block-editor');
 
-			return {
-				activeVariation: getActiveBlockVariation(),
-				selectedBlock: (getSelectedBlock() || {})?.name,
-				isActiveBlockExtensions: isActiveBlockExtensions(),
-				availableAttributes: getBlockType(name)?.attributes,
-			};
-		});
-
-		const isSelectedBlock = (name: string): boolean =>
-			selectedBlock === name;
+				return {
+					activeVariation: getActiveBlockVariation(),
+					selectedBlock: (getSelectedBlock() || {})?.name,
+					isActiveBlockExtensions: isActiveBlockExtensions(),
+					availableAttributes: getBlockType(name)?.attributes,
+				};
+			}
+		);
 
 		const [isActive, setActive] = useState(isActiveBlockExtensions);
 
@@ -140,7 +133,6 @@ export const BlockBase: ComponentType<BlockBaseProps> = memo(
 			changeExtensionCurrentBlock: setCurrentBlock,
 			changeExtensionCurrentBlockState: setCurrentState,
 			changeExtensionInnerBlockState: setInnerBlockState,
-			setExtensionsActiveBlockVariation: setActiveBlockVariation,
 		} = dispatch('blockera/extensions') || {};
 
 		const { getDeviceType } = select('blockera/editor');
@@ -286,37 +278,6 @@ export const BlockBase: ComponentType<BlockBaseProps> = memo(
 			},
 			[currentAttributes]
 		);
-
-		// While change active block variation, we should clean up blockeraCompatId because we need to running compatibilities again.
-		useEffect(() => {
-			// We should not try to clean up blockeraCompatId while not selected block because still not executing compatibility on current block.
-			if (!isSelectedBlock(name)) {
-				return;
-			}
-
-			// Create mutable constant to prevent directly change to immutable state constant.
-			let filteredAttributes = { ...attributes };
-
-			if (!isEquals(activeVariation, activeBlockVariation)) {
-				setActiveBlockVariation(activeBlockVariation);
-
-				filteredAttributes = {
-					...attributes,
-					blockeraCompatId: '',
-				};
-
-				// Prevent redundant set state!
-				if (isEquals(attributes, filteredAttributes)) {
-					return;
-				}
-
-				// Prevent of bad set state!
-				if (!isEquals(attributes, filteredAttributes)) {
-					updateAttributes(filteredAttributes);
-				}
-			}
-			// eslint-disable-next-line
-		}, [activeBlockVariation]);
 
 		const originalAttributes = useMemo(() => {
 			return omitWithPattern(


### PR DESCRIPTION

Reported bug: https://community.blockera.ai/bugs-mdhyb8nc/post/group-block-variation-control-bug-with-updating-layout-section---flex-MSd1lhFdxAGDd2c

The test file related to this feature is updated and is failing now. 