### PR TITLE
Feat: More WP blocks support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
 				"rememo": "^4.0.2"
 			},
 			"devDependencies": {
+				"@10up/cypress-wp-utils": "^0.4.0",
 				"@4tw/cypress-drag-drop": "^2.2.5",
 				"@babel/cli": "^7.22.9",
 				"@babel/core": "^7.22.9",
@@ -175,6 +176,15 @@
 				"react": "^16.8.0 || ^17.0.0 || ^18.2.0",
 				"react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0 || ^16.8.0 || ^17.0.0 || ^18.2.0",
 				"stylelint": "^14.2"
+			}
+		},
+		"node_modules/@10up/cypress-wp-utils": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/@10up/cypress-wp-utils/-/cypress-wp-utils-0.4.0.tgz",
+			"integrity": "sha512-7cNELIX6ml5V9JEU83iEyQ6dkZ77ImdR5HKjUP4oyArQogPVcFPUnokU7GInH8DicqXbESrrkxZ0IfnNtNWh+A==",
+			"dev": true,
+			"engines": {
+				"node": ">=12.0"
 			}
 		},
 		"node_modules/@4tw/cypress-drag-drop": {
@@ -51539,6 +51549,12 @@
 		}
 	},
 	"dependencies": {
+		"@10up/cypress-wp-utils": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/@10up/cypress-wp-utils/-/cypress-wp-utils-0.4.0.tgz",
+			"integrity": "sha512-7cNELIX6ml5V9JEU83iEyQ6dkZ77ImdR5HKjUP4oyArQogPVcFPUnokU7GInH8DicqXbESrrkxZ0IfnNtNWh+A==",
+			"dev": true
+		},
 		"@4tw/cypress-drag-drop": {
 			"version": "2.2.5",
 			"resolved": "https://registry.npmjs.org/@4tw/cypress-drag-drop/-/cypress-drag-drop-2.2.5.tgz",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
 		"rememo": "^4.0.2"
 	},
 	"devDependencies": {
+		"@10up/cypress-wp-utils": "^0.4.0",
 		"@4tw/cypress-drag-drop": "^2.2.5",
 		"@babel/cli": "^7.22.9",
 		"@babel/core": "^7.22.9",

--- a/packages/blocks/core/js/wordpress-blocks-list.json
+++ b/packages/blocks/core/js/wordpress-blocks-list.json
@@ -3,9 +3,9 @@
 	"data": {
 		"total": 93,
 		"supported": 76,
-		"soft-supported": 89,
-		"not-supported": 4,
-		"no-need-to-support": 13
+		"soft-supported": 90,
+		"not-supported": 3,
+		"no-need-to-support": 14
 	},
 	"supported": [
 		{
@@ -382,6 +382,11 @@
 			"name": "core/widget-group",
 			"title": "Widget Group",
 			"note": "Investigate if this block can be supported."
+		},
+		{
+			"name": "core/page-list-item",
+			"title": "Page List Item",
+			"note": "This block is not selectable and there is no ui for it for user and we do not need to support it."
 		}
 	],
 	"not-supported": [
@@ -389,11 +394,6 @@
 			"name": "core/navigation",
 			"title": "Navigation",
 			"note": "Advanced editor setting panel compatibility needed."
-		},
-		{
-			"name": "core/page-list-item",
-			"title": "Page List Item",
-			"note": "Investigate if this block can be supported."
 		},
 		{
 			"name": "core/archives",

--- a/packages/blocks/core/js/wordpress/post-featured-image/test/selectors.blocks.e2e.cy.js
+++ b/packages/blocks/core/js/wordpress/post-featured-image/test/selectors.blocks.e2e.cy.js
@@ -189,7 +189,7 @@ describe('Featured Image Block → Selectors test', () => {
 		savePage();
 		redirectToFrontPage();
 
-		cy.get('.blockera-block').within(() => {
+		cy.get('.blockera-block.wp-block-post-featured-image').within(() => {
 			cy.get('img')
 				.first()
 				.should('have.css', 'border', '5px dashed rgb(55, 230, 212)')

--- a/packages/dev-cypress/js/helpers/editor.js
+++ b/packages/dev-cypress/js/helpers/editor.js
@@ -482,32 +482,3 @@ export const reSelectBlock = (blockType = 'core/paragraph') => {
 	// reselect block
 	cy.getIframeBody().find(`[data-type="${blockType}"]`).first().click();
 };
-
-// https://github.com/10up/cypress-wp-utils/blob/013915676935410cf3390829a52bc5e0c80b6deb/src/commands/open-document-settings-sidebar.ts
-Cypress.Commands.add('openDocumentSettingsSidebar', (tab = 'Post') => {
-	cy.get('body').then(($body) => {
-		const $settingButtonIds = [
-			'button[aria-expanded="false"][aria-label="Settings"]',
-		];
-
-		$settingButtonIds.forEach(($settingButtonId) => {
-			if ($body.find($settingButtonId).length) {
-				cy.get($settingButtonId).click();
-				cy.wrap($body.find($settingButtonId)).as('sidebarButton');
-			}
-		});
-
-		const $tabSelectors = [
-			// commented from original code because it is not valid
-			// `div[role="tablist"] button:contains("${tab}")`,
-			`.edit-post-sidebar__panel-tabs button:contains("${tab}")`,
-		];
-
-		$tabSelectors.forEach(($tabSelector) => {
-			if ($body.find($tabSelector).length) {
-				cy.get($tabSelector).first().click();
-				cy.wrap($body.find($tabSelector)).as('selectedTab');
-			}
-		});
-	});
-});

--- a/packages/dev-cypress/js/support/e2e.js
+++ b/packages/dev-cypress/js/support/e2e.js
@@ -1,14 +1,15 @@
 /**
- * Internal dependencies
- */
-import { registerCommands } from './commands';
-import { loginToSite, goTo } from '../helpers';
-
-/**
  * External dependencies
  */
 import 'cypress-real-events';
 import '@cypress/code-coverage/support';
+import '@10up/cypress-wp-utils';
+
+/**
+ * Internal dependencies
+ */
+import { registerCommands } from './commands';
+import { loginToSite, goTo } from '../helpers';
 
 registerCommands();
 


### PR DESCRIPTION
In this branch we will try to add support to all WP blocks.

Remaining:
- [ ] `core/page-list-item`
- [ ] `core/navigation`
- [ ] `core/archives`
- [ ] `core/calendar`
