### PR TITLE
fix: Error while current block theme have not variable settings

### DIFF
--- a/packages/data/CHANGELOG.md
+++ b/packages/data/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Fixed
+- Fixed an issue where block themes without variable settings for Spacing and Color would cause errors. [[🔗 Bug](https://community.blockera.ai/bugs-mdhyb8nc/post/theme-defined-spacing-does-not-fall-back-to-wordpress-defaults-Ft6gpFAjwsMoNA8)].
+
+
 ## 1.0.0 (2024-12-08)
 
 ### Fixed

--- a/packages/data/js/variables/color.js
+++ b/packages/data/js/variables/color.js
@@ -35,16 +35,23 @@ export const getColors: () => Array<VariableItem> = memoize(
 				theme: themeName,
 			};
 
-			return getBlockEditorSettings()?.__experimentalFeatures?.color?.palette?.theme.map(
-				(item) => {
-					return {
-						name: item.name,
-						id: item.slug,
-						value: item.color,
-						reference,
-					};
-				}
-			);
+			if (
+				!isUndefined(
+					getBlockEditorSettings()?.__experimentalFeatures?.color
+						?.palette?.theme
+				)
+			) {
+				return getBlockEditorSettings()?.__experimentalFeatures?.color?.palette?.theme.map(
+					(item) => {
+						return {
+							name: item.name,
+							id: item.slug,
+							value: item.color,
+							reference,
+						};
+					}
+				);
+			}
 		}
 
 		if (

--- a/packages/data/js/variables/spacing.js
+++ b/packages/data/js/variables/spacing.js
@@ -36,16 +36,23 @@ export const getSpacings: () => Array<VariableItem> = memoize(
 				theme: themeName,
 			};
 
-			return getBlockEditorSettings()?.__experimentalFeatures?.spacing?.spacingSizes?.theme.map(
-				(item) => {
-					return {
-						name: item.name,
-						id: item.slug,
-						value: item.size,
-						reference,
-					};
-				}
-			);
+			if (
+				!isUndefined(
+					getBlockEditorSettings()?.__experimentalFeatures?.spacing
+						?.spacingSizes?.theme
+				)
+			) {
+				return getBlockEditorSettings()?.__experimentalFeatures?.spacing?.spacingSizes?.theme.map(
+					(item) => {
+						return {
+							name: item.name,
+							id: item.slug,
+							value: item.size,
+							reference,
+						};
+					}
+				);
+			}
 		}
 
 		const spaces =

--- a/packages/data/js/variables/width-size.js
+++ b/packages/data/js/variables/width-size.js
@@ -21,6 +21,7 @@ export const getWidthSizes: () => Array<VariableItem> | [] = memoize(
 		const reference = {
 			type: 'preset',
 		};
+
 		const layout = getBlockEditorSettings()?.__experimentalFeatures?.layout;
 
 		if (isUndefined(layout)) {


### PR DESCRIPTION
Related bug: https://community.blockera.ai/bugs-mdhyb8nc/post/theme-defined-spacing-does-not-fall-back-to-wordpress-defaults-Ft6gpFAjwsMoNA8