### PR TITLE
Fix: Variable colors are showing lighter in Blockera Variables

### DIFF
--- a/packages/controls/CHANGELOG.md
+++ b/packages/controls/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+## Bug Fixes
+- Fixed an issue where variable colors appeared lighter in Blockera Variables than in the original variables  [[🔗 Bug](https://community.blockera.ai/bugs-mdhyb8nc/post/showing-theme-colors-as-they-are-4VjzJz6qKKL9HdQ)]
+
+
 ## 1.0.0 (2024-12-08)
 
 ### Bug Fixes

--- a/packages/controls/js/value-addons/components/picker/picker-value-item.scss
+++ b/packages/controls/js/value-addons/components/picker/picker-value-item.scss
@@ -42,9 +42,9 @@
 		pointer-events: none;
 		display: flex;
 		align-items: center;
-		opacity: 0.5;
 
 		svg {
+			opacity: 0.5;
 			fill: currentColor;
 		}
 	}


### PR DESCRIPTION
Reported bug: https://community.blockera.ai/bugs-mdhyb8nc/post/showing-theme-colors-as-they-are-4VjzJz6qKKL9HdQ