### PR TITLE
feat: block-supports schemas

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -7,7 +7,7 @@ on:
             - '**.js'
             - '**.css'
             - '**.scss'
-            - 'packages/**/*.php'
+            - '**.php'
             # Changes to any NPM related files could affect the outcome.
             - '**package*.json'
             # These files configures ESLint. Changes could affect the outcome.
@@ -62,4 +62,4 @@ jobs:
             - uses: preactjs/compressed-size-action@v2
               with:
                   repo-token: '${{ secrets.BLOCKERABOT_PAT }}'
-                  pattern: '{dist/**/*.min.js,dist/**/*.css,blockera.zip}'
+                  pattern: '{dist/**/*.min.js,dist/**/*.min.css,blockera.zip,packages/**/*.php,!**/test/**,!**/tests/**}'

--- a/packages/editor/js/extensions/libs/border-and-shadow/css-generators/border-radius-generator.js
+++ b/packages/editor/js/extensions/libs/border-and-shadow/css-generators/border-radius-generator.js
@@ -2,38 +2,63 @@
  * Blockera dependencies
  */
 import { getValueAddonRealValue } from '@blockera/controls';
-
 /**
  * Internal dependencies
  */
 import { createCssDeclarations } from '../../../../style-engine';
+import { getBlockSupportStyleEngineConfig } from '../../../utils';
 
 export function BorderRadiusGenerator(id, props) {
-	const { attributes } = props;
+	const { attributes, supports, blockeraStyleEngineConfig } = props;
 
 	if (!attributes?.blockeraBorderRadius) {
 		return '';
 	}
 
+	if (blockeraStyleEngineConfig?.blockeraBorderRadius) {
+		supports.blockeraBorderRadius['style-engine-config'] =
+			blockeraStyleEngineConfig.blockeraBorderRadius;
+	}
+
 	const properties = {};
 
 	if (attributes?.blockeraBorderRadius?.type === 'all') {
-		properties['border-radius'] = getValueAddonRealValue(
-			attributes.blockeraBorderRadius.all
-		);
+		properties[
+			getBlockSupportStyleEngineConfig(
+				supports,
+				'blockeraBorderRadius',
+				'all'
+			)
+		] = getValueAddonRealValue(attributes.blockeraBorderRadius.all);
 	} else {
-		properties['border-top-left-radius'] = getValueAddonRealValue(
-			attributes.blockeraBorderRadius.topLeft
-		);
-		properties['border-top-right-radius'] = getValueAddonRealValue(
-			attributes.blockeraBorderRadius.topRight
-		);
-		properties['border-bottom-left-radius'] = getValueAddonRealValue(
-			attributes.blockeraBorderRadius.bottomLeft
-		);
-		properties['border-bottom-right-radius'] = getValueAddonRealValue(
-			attributes.blockeraBorderRadius.bottomRight
-		);
+		properties[
+			getBlockSupportStyleEngineConfig(
+				supports,
+				'blockeraBorderRadius',
+				'topLeft'
+			)
+		] = getValueAddonRealValue(attributes.blockeraBorderRadius.topLeft);
+		properties[
+			getBlockSupportStyleEngineConfig(
+				supports,
+				'blockeraBorderRadius',
+				'topRight'
+			)
+		] = getValueAddonRealValue(attributes.blockeraBorderRadius.topRight);
+		properties[
+			getBlockSupportStyleEngineConfig(
+				supports,
+				'blockeraBorderRadius',
+				'bottomLeft'
+			)
+		] = getValueAddonRealValue(attributes.blockeraBorderRadius.bottomLeft);
+		properties[
+			getBlockSupportStyleEngineConfig(
+				supports,
+				'blockeraBorderRadius',
+				'bottomRight'
+			)
+		] = getValueAddonRealValue(attributes.blockeraBorderRadius.bottomRight);
 	}
 
 	if (!Object.keys(properties).length) {

--- a/packages/editor/js/extensions/libs/border-and-shadow/styles.js
+++ b/packages/editor/js/extensions/libs/border-and-shadow/styles.js
@@ -34,6 +34,7 @@ export const BorderAndShadowStyles = ({
 	masterState,
 	currentBlock,
 	activeDeviceType,
+	supports: blockSupports,
 	selectors: blockSelectors,
 	defaultAttributes: attributes,
 	attributes: currentBlockAttributes,
@@ -48,8 +49,10 @@ export const BorderAndShadowStyles = ({
 
 	const blockProps = {
 		clientId,
+		supports,
 		blockName,
 		attributes: currentBlockAttributes,
+		blockeraStyleEngineConfig: blockSupports?.blockeraStyleEngineConfig,
 	};
 
 	const sharedParams = {

--- a/packages/editor/js/extensions/libs/types/StylesProps.js
+++ b/packages/editor/js/extensions/libs/types/StylesProps.js
@@ -13,7 +13,7 @@ export type StylesProps = {
 	clientId: string,
 	blockName: string,
 	selectors: Object,
-	// supports?: Object,
+	supports: Object,
 	attributes: Object,
 	masterState: TStates,
 	defaultAttributes: Object,

--- a/packages/editor/js/extensions/utils/index.js
+++ b/packages/editor/js/extensions/utils/index.js
@@ -63,8 +63,9 @@ export const getBlockSupportCategory = (name: string): Object => {
 };
 
 /**
+ * Get block support fallback with support name.
  *
- * @param {Object} supports the block supports list of support category.
+ * @param {Object} supports the block support list of support category.
  * @param {string} support the support name.
  *
  * @return {Object} the support details.
@@ -73,6 +74,80 @@ export const getBlockSupportFallback = (
 	supports: Object,
 	support: string
 ): Object => {
-	return supports?.find((_support): boolean => _support?.name === support)
-		?.fallback;
+	return supports[support]?.fallback;
+};
+
+/**
+ * Get block support styleEngineConfig with support name.
+ *
+ * @param {Object} supports the block support list of support category.
+ * @param {string} support the support name.
+ *
+ * @return {Object} the support styleEngineConfig.
+ */
+export const getBlockSupportStyleEngineConfig = (
+	supports: Object,
+	support: string
+): Object => {
+	return supports[support]?.['style-engine-config'];
+};
+
+/**
+ * Get block support note with support name.
+ *
+ * @param {Object} supports the block support list of support category.
+ * @param {string} support the support name.
+ *
+ * @return {Object} the support note.
+ */
+export const getBlockSupportNote = (
+	supports: Object,
+	support: string
+): Object => {
+	return supports[support]?.note;
+};
+
+/**
+ * Get block support css property with support name.
+ *
+ * @param {Object} supports the block support list of support category.
+ * @param {string} support the support name.
+ *
+ * @return {Object} the support css property.
+ */
+export const getBlockSupportCssProperty = (
+	supports: Object,
+	support: string
+): Object => {
+	return supports[support]?.['css-property'];
+};
+
+/**
+ * Get block support status with support name.
+ *
+ * @param {Object} supports the block support list of support category.
+ * @param {string} support the support name.
+ *
+ * @return {Object} the support status.
+ */
+export const getBlockSupportStatus = (
+	supports: Object,
+	support: string
+): Object => {
+	return supports[support]?.status;
+};
+
+/**
+ * Get block support description with support name.
+ *
+ * @param {Object} supports the block support list of support category.
+ * @param {string} support the support name.
+ *
+ * @return {Object} the support description.
+ */
+export const getBlockSupportDescription = (
+	supports: Object,
+	support: string
+): Object => {
+	return supports[support]?.description;
 };

--- a/packages/editor/js/extensions/utils/index.js
+++ b/packages/editor/js/extensions/utils/index.js
@@ -82,14 +82,16 @@ export const getBlockSupportFallback = (
  *
  * @param {Object} supports the block support list of support category.
  * @param {string} support the support name.
+ * @param {string} property the property name.
  *
  * @return {Object} the support styleEngineConfig.
  */
 export const getBlockSupportStyleEngineConfig = (
 	supports: Object,
-	support: string
+	support: string,
+	property: string
 ): Object => {
-	return supports[support]?.['style-engine-config'];
+	return supports[support]?.['style-engine-config']?.[property];
 };
 
 /**

--- a/packages/editor/js/schemas/block-supports/background-block-supports-list.json
+++ b/packages/editor/js/schemas/block-supports/background-block-supports-list.json
@@ -1,10 +1,9 @@
 {
 	"$schema": "../block.supports.schema.json",
 	"title": "background",
-	"supports": [
-		{
+	"supports": {
+		"blockeraBackground": {
 			"status": true,
-			"name": "blockeraBackground",
 			"css-property": "background-image",
 			"fallback": [
 				"background.backgroundImage",
@@ -13,9 +12,8 @@
 			],
 			"description": "Support for \"background-image\" value."
 		},
-		{
+		"blockeraBackgroundClip": {
 			"status": true,
-			"name": "blockeraBackgroundClip",
 			"css-property": "background-clip",
 			"fallback": [
 				"background.backgroundImage",
@@ -24,9 +22,8 @@
 			],
 			"description": "Support for \"blockeraBackgroundClip\" value."
 		},
-		{
+		"blockeraBackgroundColor": {
 			"status": true,
-			"name": "blockeraBackgroundColor",
 			"css-property": "background-color",
 			"fallback": [
 				"color.background",
@@ -35,5 +32,5 @@
 			],
 			"description": "Support for \"blockeraBackgroundColor\" value, this is mirror for WordPress block core \"color.background\" support"
 		}
-	]
+	}
 }

--- a/packages/editor/js/schemas/block-supports/border-block-supports-list.json
+++ b/packages/editor/js/schemas/block-supports/border-block-supports-list.json
@@ -11,6 +11,13 @@
 		"blockeraBorderRadius": {
 			"status": true,
 			"css-property": "border-radius",
+			"style-engine-config": {
+				"all": "border-radius",
+				"topLeft": "border-top-left-radius",
+				"topRight": "border-top-right-radius",
+				"bottomLeft": "border-bottom-left-radius",
+				"bottomRight": "border-bottom-right-radius"
+			},
 			"fallback": ["border.radius", "border.color", "border"],
 			"description": "Support for \"blockeraBorder\" value, this is mirror for WordPress block core \"border-radius\" support"
 		}

--- a/packages/editor/js/schemas/block-supports/border-block-supports-list.json
+++ b/packages/editor/js/schemas/block-supports/border-block-supports-list.json
@@ -1,20 +1,18 @@
 {
 	"$schema": "../block.supports.schema.json",
 	"title": "border",
-	"supports": [
-		{
+	"supports": {
+		"blockeraBorder": {
 			"status": true,
-			"name": "blockeraBorder",
 			"css-property": "border",
 			"fallback": ["border.color", "border"],
 			"description": "Support for \"blockeraBorder\" value, this is mirror for WordPress block core \"border\" support"
 		},
-		{
+		"blockeraBorderRadius": {
 			"status": true,
-			"name": "blockeraBorderRadius",
 			"css-property": "border-radius",
 			"fallback": ["border.radius", "border.color", "border"],
 			"description": "Support for \"blockeraBorder\" value, this is mirror for WordPress block core \"border-radius\" support"
 		}
-	]
+	}
 }

--- a/packages/editor/js/schemas/block-supports/box-shadow-block-supports-list.json
+++ b/packages/editor/js/schemas/block-supports/box-shadow-block-supports-list.json
@@ -1,13 +1,12 @@
 {
 	"$schema": "../block.supports.schema.json",
 	"title": "box-shadow",
-	"supports": [
-		{
+	"supports": {
+		"blockeraBoxShadow": {
 			"status": true,
-			"name": "blockeraBoxShadow",
 			"css-property": "box-shadow",
 			"fallback": "shadow",
 			"description": "Support for \"blockeraBoxShadow\" value."
 		}
-	]
+	}
 }

--- a/packages/editor/js/schemas/block-supports/divider-block-supports-list.json
+++ b/packages/editor/js/schemas/block-supports/divider-block-supports-list.json
@@ -1,13 +1,12 @@
 {
 	"$schema": "../block.supports.schema.json",
 	"title": "divider",
-	"supports": [
-		{
+	"supports": {
+		"blockeraDivider": {
 			"status": true,
-			"name": "blockeraDivider",
 			"css-property": "divider",
 			"fallback": "divider",
 			"description": "Support for \"blockeraDivider\" value."
 		}
-	]
+	}
 }

--- a/packages/editor/js/schemas/block-supports/effects-block-supports-list.json
+++ b/packages/editor/js/schemas/block-supports/effects-block-supports-list.json
@@ -1,97 +1,84 @@
 {
 	"$schema": "../block.supports.schema.json",
 	"title": "effects",
-	"supports": [
-		{
+	"supports": {
+		"blockeraTransform": {
 			"status": true,
-			"name": "blockeraTransform",
 			"css-property": "transform",
 			"fallback": "transform",
 			"description": "Support for \"blockeraTransform\" value."
 		},
-		{
+		"blockeraTransition": {
 			"status": true,
-			"name": "blockeraTransition",
 			"css-property": "transition",
 			"fallback": "transition",
 			"description": "Support for \"blockeraTransition\" value."
 		},
-		{
+		"blockeraBlendMode": {
 			"status": true,
-			"name": "blockeraBlendMode",
 			"css-property": "mix-blend-mode",
 			"fallback": "mix-blend-mode",
 			"description": "Support for \"blockeraBlendMode\" value."
 		},
-		{
+		"blockeraBackdropFilter": {
 			"status": true,
-			"name": "blockeraBackdropFilter",
 			"css-property": "backdrop-filter",
 			"fallback": "backdrop-filter",
 			"description": "Support for \"blockeraBackdropFilter\" value."
 		},
-		{
+		"blockeraTransformSelfOrigin": {
 			"status": true,
-			"name": "blockeraTransformSelfOrigin",
 			"css-property": "self-origin",
 			"fallback": "self-origin",
 			"description": "Support for \"blockeraTransformSelfOrigin\" value."
 		},
-		{
+		"blockeraMask": {
 			"status": true,
-			"name": "blockeraMask",
 			"css-property": "mask",
 			"fallback": "mask",
 			"description": "Support for \"blockeraMask\" value."
 		},
-		{
+		"blockeraDivider": {
 			"status": true,
-			"name": "blockeraDivider",
 			"css-property": "divider",
 			"fallback": "divider",
 			"description": "Support for \"blockeraDivider\" value."
 		},
-		{
+		"blockeraTransformChildOrigin": {
 			"status": true,
-			"name": "blockeraTransformChildOrigin",
 			"css-property": "child-origin",
 			"fallback": "child-origin",
 			"description": "Support for \"blockeraTransformChildOrigin\" value."
 		},
-		{
+		"blockeraBackfaceVisibility": {
 			"status": true,
-			"name": "blockeraBackfaceVisibility",
 			"css-property": "backface-visibility",
 			"fallback": "backface-visibility",
 			"description": "Support for \"blockeraBackfaceVisibility\" value."
 		},
-		{
+		"blockeraTransformSelfPerspective": {
 			"status": true,
-			"name": "blockeraTransformSelfPerspective",
 			"css-property": "self-perspective",
 			"fallback": "self-perspective",
 			"description": "Support for \"blockeraTransformSelfPerspective\" value."
 		},
-		{
+		"blockeraTransformChildPerspective": {
 			"status": true,
-			"name": "blockeraTransformChildPerspective",
 			"css-property": "child-perspective",
 			"fallback": "child-perspective",
 			"description": "Support for \"blockeraTransformChildPerspective\" value."
 		},
-		{
+		"blockeraFilter": {
 			"status": true,
-			"name": "blockeraFilter",
 			"css-property": "filter",
 			"fallback": ["filter.duotone", "filter"],
 			"description": "Support for \"blockeraFilter\" value."
 		},
-		{
+		"blockeraOpacity": {
 			"status": true,
-			"name": "blockeraOpacity",
 			"css-property": "opacity",
 			"fallback": "opacity",
 			"description": "Support for \"blockeraOpacity\" value."
 		}
-	]
+	}
 }

--- a/packages/editor/js/schemas/block-supports/layout-block-supports-list.json
+++ b/packages/editor/js/schemas/block-supports/layout-block-supports-list.json
@@ -1,62 +1,54 @@
 {
 	"$schema": "../block.supports.schema.json",
 	"title": "layout",
-	"supports": [
-		{
+	"supports": {
+		"blockeraGap": {
 			"status": true,
-			"name": "blockeraGap",
 			"css-property": "gap",
 			"fallback": ["gap"],
 			"description": "Support for \"blockeraGap\" value, this is mirror for WordPress block core \"gap\" support"
 		},
-		{
+		"blockeraFlexChildSizing": {
 			"status": true,
-			"name": "blockeraFlexChildSizing",
 			"css-property": "flex",
 			"fallback": ["flex"],
 			"description": "Support for \"blockeraFlexChildSizing\" value, this is mirror for WordPress block core \"flex\" support"
 		},
-		{
+		"blockeraFlexChildOrder": {
 			"status": true,
-			"name": "blockeraFlexChildOrder",
 			"css-property": "order",
 			"fallback": ["order"],
 			"description": "Support for \"blockeraFlexChildOrder\" value, this is mirror for WordPress block core \"order\" support"
 		},
-		{
+		"blockeraDisplay": {
 			"status": true,
-			"name": "blockeraDisplay",
 			"css-property": "display",
 			"fallback": ["display"],
 			"description": "Support for \"blockeraDisplay\" value, this is mirror for WordPress block core \"display\" support"
 		},
-		{
+		"blockeraFlexWrap": {
 			"status": true,
-			"name": "blockeraFlexWrap",
 			"css-property": "flex-wrap",
 			"fallback": ["flex-wrap"],
 			"description": "Support for \"blockeraFlexWrap\" value."
 		},
-		{
+		"blockeraFlexChildAlign": {
 			"status": true,
-			"name": "blockeraFlexChildAlign",
 			"css-property": "align-self",
 			"fallback": ["align-self"],
 			"description": "Support for \"blockeraFlexChildAlign\" value."
 		},
-		{
+		"blockeraAlignContent": {
 			"status": true,
-			"name": "blockeraAlignContent",
 			"css-property": "align-content",
 			"fallback": ["align-content"],
 			"description": "Support for \"blockeraAlignContent\" value."
 		},
-		{
+		"blockeraFlexLayout": {
 			"status": true,
-			"name": "blockeraFlexLayout",
 			"css-property": "flex-direction",
 			"fallback": ["flex-direction"],
 			"description": "Support for \"blockeraFlexLayout\" value."
 		}
-	]
+	}
 }

--- a/packages/editor/js/schemas/block-supports/mouse-block-supports-list.json
+++ b/packages/editor/js/schemas/block-supports/mouse-block-supports-list.json
@@ -1,27 +1,24 @@
 {
 	"$schema": "../block.supports.schema.json",
 	"title": "mouse",
-	"supports": [
-		{
+	"supports": {
+		"blockeraCursor": {
 			"status": true,
-			"name": "blockeraCursor",
 			"css-property": "cursor",
 			"fallback": ["cursor"],
 			"description": "Support for \"blockeraCursor\" value."
 		},
-		{
+		"blockeraUserSelect": {
 			"status": true,
-			"name": "blockeraUserSelect",
 			"css-property": "user-select",
 			"fallback": ["user-select"],
 			"description": "Support for \"blockeraUserSelect\" value."
 		},
-		{
+		"blockeraPointerEvents": {
 			"status": true,
-			"name": "blockeraPointerEvents",
 			"css-property": "pointer-events",
 			"fallback": ["pointer-events"],
 			"description": "Support for \"blockeraPointerEvents\" value."
 		}
-	]
+	}
 }

--- a/packages/editor/js/schemas/block-supports/outline-block-supports-list.json
+++ b/packages/editor/js/schemas/block-supports/outline-block-supports-list.json
@@ -1,20 +1,18 @@
 {
 	"$schema": "../block.supports.schema.json",
 	"title": "outline",
-	"supports": [
-		{
+	"supports": {
+		"blockeraOutline": {
 			"status": true,
-			"name": "blockeraOutline",
 			"css-property": "outline",
 			"fallback": ["outline.color", "outline"],
 			"description": "Support for \"blockeraOutline\" value."
 		},
-		{
+		"blockeraOffset": {
 			"status": true,
-			"name": "blockeraOffset",
 			"css-property": "outline-offset",
 			"fallback": ["outline.offset", "outline"],
 			"description": "Support for \"blockeraOffset\" value."
 		}
-	]
+	}
 }

--- a/packages/editor/js/schemas/block-supports/position-block-supports-list.json
+++ b/packages/editor/js/schemas/block-supports/position-block-supports-list.json
@@ -1,20 +1,18 @@
 {
 	"$schema": "../block.supports.schema.json",
 	"title": "position",
-	"supports": [
-		{
+	"supports": {
+		"blockeraPosition": {
 			"status": true,
-			"name": "blockeraPosition",
 			"css-property": "position",
 			"fallback": ["position"],
 			"description": "Support for \"blockeraPosition\" value."
 		},
-		{
+		"blockeraZIndex": {
 			"status": true,
-			"name": "blockeraZIndex",
 			"css-property": "z-index",
 			"fallback": ["z-index"],
 			"description": "Support for \"blockeraZIndex\" value."
 		}
-	]
+	}
 }

--- a/packages/editor/js/schemas/block-supports/size-block-supports-list.json
+++ b/packages/editor/js/schemas/block-supports/size-block-supports-list.json
@@ -1,24 +1,21 @@
 {
 	"$schema": "../block.supports.schema.json",
 	"title": "size",
-	"supports": [
-		{
+	"supports": {
+		"blockeraWidth": {
 			"status": true,
-			"name": "blockeraWidth",
 			"fallback": ["dimensions.width", "dimensions", "width"],
 			"css-property": "width",
 			"description": "Support for \"blockeraWidth\" size, this is mirror for WordPress block core \"width\" support."
 		},
-		{
+		"blockeraHeight": {
 			"status": true,
-			"name": "blockeraHeight",
 			"fallback": ["dimensions.height", "dimensions", "height", "width"],
 			"css-property": "height",
 			"description": "Support for \"blockeraHeight\" size, this is mirror for WordPress block core \"height\" support."
 		},
-		{
+		"blockeraMinWidth": {
 			"status": true,
-			"name": "blockeraMinWidth",
 			"css-property": "min-width",
 			"fallback": [
 				"dimensions.minWidth",
@@ -28,9 +25,8 @@
 			],
 			"description": "Support for \"blockeraMinWidth\" size, this is mirror for WordPress block core \"dimensions.minWidth\" support."
 		},
-		{
+		"blockeraMaxWidth": {
 			"status": true,
-			"name": "blockeraMaxWidth",
 			"css-property": "max-width",
 			"fallback": [
 				"dimensions.maxWidth",
@@ -40,9 +36,8 @@
 			],
 			"description": "Support for \"blockeraMaxWidth\" size, this is mirror for WordPress block core \"dimensions.maxWidth\" support."
 		},
-		{
+		"blockeraMinHeight": {
 			"status": true,
-			"name": "blockeraMinHeight",
 			"css-property": "min-height",
 			"fallback": [
 				"dimensions.minHeight",
@@ -53,9 +48,8 @@
 			],
 			"description": "Support for \"blockeraMinHeight\" size, this is mirror for WordPress block core \"dimensions.minHeight\" support."
 		},
-		{
+		"blockeraMaxHeight": {
 			"status": true,
-			"name": "blockeraMaxHeight",
 			"css-property": "max-height",
 			"fallback": [
 				"dimensions.maxHeight",
@@ -66,40 +60,35 @@
 			],
 			"description": "Support for \"blockeraMaxHeight\" size, this is mirror for WordPress block core \"dimensions.maxHeight\" support."
 		},
-		{
+		"blockeraRatio": {
 			"status": true,
-			"name": "blockeraRatio",
 			"css-property": "aspect-ratio",
 			"fallback": ["dimensions.aspectRatio", "dimensions"],
 			"description": "Support for \"blockeraRatio\" value, this is mirror for WordPress block core \"dimensions.aspectRatio\" support."
 		},
-		{
+		"blockeraOverflow": {
 			"status": true,
-			"name": "blockeraOverflow",
 			"css-property": "overflow",
 			"fallback": ["overflow", "dimensions"],
 			"description": "Support for \"blockeraOverflow\" value, this is mirror for WordPress block core \"overflow\" support."
 		},
-		{
+		"blockeraFit": {
 			"status": true,
-			"name": "blockeraFit",
 			"css-property": "object-fit",
 			"fallback": ["object-fit", "dimensions"],
 			"description": "Support for \"blockeraFit\" value, this is mirror for WordPress block core \"object-fit\" support."
 		},
-		{
+		"blockeraFitPosition": {
 			"status": true,
-			"name": "blockeraFitPosition",
 			"css-property": "object-position",
 			"fallback": ["object-position", "dimensions"],
 			"description": "Support for \"blockeraFitPosition\" value, this is mirror for WordPress block core \"object-position\" support."
 		},
-		{
+		"blockeraBoxSizing": {
 			"status": true,
-			"name": "blockeraBoxSizing",
 			"css-property": "box-sizing",
 			"fallback": ["box-sizing", "dimensions"],
 			"description": "Support for \"blockeraBoxSizing\" value."
 		}
-	]
+	}
 }

--- a/packages/editor/js/schemas/block-supports/spacing-block-supports-list.json
+++ b/packages/editor/js/schemas/block-supports/spacing-block-supports-list.json
@@ -1,13 +1,12 @@
 {
 	"$schema": "../block.supports.schema.json",
 	"title": "spacing",
-	"supports": [
-		{
+	"supports": {
+		"blockeraSpacing": {
 			"status": true,
-			"name": "blockeraSpacing",
 			"css-property": "spacing",
 			"fallback": ["spacing.margin", "spacing.padding", "spacing"],
 			"description": "Support for \"blockeraSpacing\" value, this is mirror for WordPress block core \"spacing\" support."
 		}
-	]
+	}
 }

--- a/packages/editor/js/schemas/block-supports/text-shadow-block-supports-list.json
+++ b/packages/editor/js/schemas/block-supports/text-shadow-block-supports-list.json
@@ -1,13 +1,12 @@
 {
 	"$schema": "../block.supports.schema.json",
 	"title": "text-shadow",
-	"supports": [
-		{
+	"supports": {
+		"blockeraTextShadow": {
 			"status": true,
-			"name": "blockeraTextShadow",
 			"css-property": "text-shadow",
 			"fallback": ["text-shadow"],
 			"description": "Support for \"blockeraTextShadow\" value."
 		}
-	]
+	}
 }

--- a/packages/editor/js/schemas/block-supports/typography-block-supports-list.json
+++ b/packages/editor/js/schemas/block-supports/typography-block-supports-list.json
@@ -1,172 +1,108 @@
 {
 	"$schema": "../block.supports.schema.json",
 	"title": "typography",
-	"supports": [
-		{
+	"supports": {
+		"blockeraFontFamily": {
 			"status": true,
-			"name": "blockeraFontFamily",
 			"css-property": "font-family",
-			"fallback": [
-				"font-size"
-			],
+			"fallback": ["font-size"],
 			"description": "Support for \"blockeraFontFamily\" value."
 		},
-		{
+		"blockeraFontAppearance": {
 			"status": true,
-			"name": "blockeraFontAppearance",
 			"css-property": "font-weight",
-			"fallback": [
-				"font-size"
-			],
+			"fallback": ["font-size"],
 			"description": "Support for \"blockeraFontAppearance\" value."
 		},
-		{
+		"blockeraTextShadow": {
 			"status": true,
-			"name": "blockeraTextShadow",
 			"css-property": "text-shadow",
-			"fallback": [
-				"text-shadow"
-			],
+			"fallback": ["text-shadow"],
 			"description": "Support for \"blockeraTextShadow\" value."
 		},
-		{
+		"blockeraFontColor": {
 			"status": true,
-			"name": "blockeraFontColor",
 			"css-property": "color",
-			"fallback": [
-				"color.text",
-				"color",
-				"typography"
-			],
+			"fallback": ["color.text", "color", "typography"],
 			"description": "Support for \"blockeraFontColor\" value, this is mirror for WordPress block core \"color\" support."
 		},
-		{
+		"blockeraFontSize": {
 			"status": true,
-			"name": "blockeraFontSize",
 			"css-property": "font-size",
-			"fallback": [
-				"typography.fontSize",
-				"typography"
-			],
+			"fallback": ["typography.fontSize", "typography"],
 			"description": "Support for \"blockeraFontSize\" value, this is mirror for WordPress block core \"fontSize\" support."
 		},
-		{
+		"blockeraDirection": {
 			"status": true,
-			"name": "blockeraDirection",
 			"css-property": "direction",
-			"fallback": [
-				"direction",
-				"typography"
-			],
+			"fallback": ["direction", "typography"],
 			"description": "Support for \"blockeraDirection\" value, this is mirror for WordPress block core \"direction\" support."
 		},
-		{
+		"blockeraTextAlign": {
 			"status": true,
-			"name": "blockeraTextAlign",
 			"css-property": "text-align",
-			"fallback": [
-				"text-align",
-				"typography"
-			],
+			"fallback": ["text-align", "typography"],
 			"description": "Support for \"blockeraTextAlign\" value, this is mirror for WordPress block core \"align\" support."
 		},
-		{
+		"blockeraWordBreak": {
 			"status": true,
-			"name": "blockeraWordBreak",
 			"css-property": "word-break",
-			"fallback": [
-				"word-break",
-				"typography"
-			],
+			"fallback": ["word-break", "typography"],
 			"description": "Support for \"blockeraWordBreak\" value, this is mirror for WordPress block core \"word-break\" support."
 		},
-		{
+		"blockeraTextIndent": {
 			"status": true,
-			"name": "blockeraTextIndent",
 			"css-property": "text-indent",
-			"fallback": [
-				"text-indent",
-				"typography"
-			],
+			"fallback": ["text-indent", "typography"],
 			"description": "Support for \"blockeraTextIndent\" value, this is mirror for WordPress block core \"text-indent\" support."
 		},
-		{
+		"blockeraLineHeight": {
 			"status": true,
-			"name": "blockeraLineHeight",
 			"css-property": "line-height",
-			"fallback": [
-				"typography.lineHeight",
-				"typography"
-			],
+			"fallback": ["typography.lineHeight", "typography"],
 			"description": "Support for \"blockeraLineHeight\" value, this is mirror for WordPress block core \"lineHeight\" support."
 		},
-		{
+		"blockeraWordSpacing": {
 			"status": true,
-			"name": "blockeraWordSpacing",
 			"css-property": "word-spacing",
-			"fallback": [
-				"word-spacing",
-				"typography"
-			],
+			"fallback": ["word-spacing", "typography"],
 			"description": "Support for \"blockeraWordSpacing\" value, this is mirror for WordPress block core \"word-spacing\" support."
 		},
-		{
+		"blockeraTextColumns": {
 			"status": true,
-			"name": "blockeraTextColumns",
 			"css-property": "column-count",
-			"fallback": [
-				"typography.textColumns",
-				"typography"
-			],
+			"fallback": ["typography.textColumns", "typography"],
 			"description": "Support for \"blockeraTextColumns\" value, this is mirror for WordPress block core \"column-count\" support."
 		},
-		{
+		"blockeraTextTransform": {
 			"status": true,
-			"name": "blockeraTextTransform",
 			"css-property": "text-transform",
-			"fallback": [
-				"typography.textTransform",
-				"typography"
-			],
+			"fallback": ["typography.textTransform", "typography"],
 			"description": "Support for \"blockeraTextTransform\" value, this is mirror for WordPress block core \"text-transform\" support."
 		},
-		{
+		"blockeraLetterSpacing": {
 			"status": true,
-			"name": "blockeraLetterSpacing",
 			"css-property": "letter-spacing",
-			"fallback": [
-				"typography"
-			],
+			"fallback": ["typography"],
 			"description": "Support for \"blockeraLetterSpacing\" value, this is mirror for WordPress block core \"letter-spacing\" support."
 		},
-		{
+		"blockeraTextDecoration": {
 			"status": true,
-			"name": "blockeraTextDecoration",
 			"css-property": "text-decoration",
-			"fallback": [
-				"typography.textDecoration",
-				"typography"
-			],
+			"fallback": ["typography.textDecoration", "typography"],
 			"description": "Support for \"blockeraTextDecoration\" value, this is mirror for WordPress block core \"text-decoration\" support."
 		},
-		{
+		"blockeraTextOrientation": {
 			"status": true,
-			"name": "blockeraTextOrientation",
 			"css-property": "text-orientation",
-			"fallback": [
-				"typography.writingMode",
-				"typography"
-			],
+			"fallback": ["typography.writingMode", "typography"],
 			"description": "Support for \"blockeraTextOrientation\" value."
 		},
-		{
+		"blockeraTextStroke": {
 			"status": true,
-			"name": "blockeraTextStroke",
 			"css-property": "-webkit-text-stroke-color",
-			"fallback": [
-				"typography"
-			],
+			"fallback": ["typography"],
 			"description": "Support for \"blockeraTextStroke\" value."
 		}
-	]
+	}
 }

--- a/packages/editor/js/schemas/block.supports.schema.json
+++ b/packages/editor/js/schemas/block.supports.schema.json
@@ -6,17 +6,13 @@
 	"properties": {
 		"supports": {
 			"description": "Supports map for Block Supports property by Blockera.",
-			"type": "array",
-			"items": {
+			"type": "object",
+			"additionalProperties": {
 				"type": "object",
 				"properties": {
 					"status": {
 						"description": "The block support status.",
 						"type": "boolean"
-					},
-					"name": {
-						"description": "The block support name (ID).",
-						"type": "string"
 					},
 					"fallback": {
 						"description": "The list of fallback ids for block support name.",
@@ -26,12 +22,16 @@
 						"description": "The standard css property.",
 						"type": "string"
 					},
+					"style-engine-config": {
+						"description": "The style engine config.",
+						"type": "object"
+					},
 					"note": {
 						"description": "Extra notes for developers.",
 						"type": "string"
 					}
 				},
-				"description": "The shared list of block supports, with consideration fallback ids."
+				"description": "The shared list of block supports, including fallback identifiers for backwards compatibility and style engine config."
 			}
 		}
 	},

--- a/packages/editor/js/style-engine/utils.js
+++ b/packages/editor/js/style-engine/utils.js
@@ -56,6 +56,8 @@ export const computedCssDeclarations = (
 		clientId: string,
 		attributes: Object,
 		blockName: string,
+		supports: Object,
+		blockeraStyleEngineConfig: Object,
 	}
 ): Array<string> => {
 	const output = [];

--- a/packages/editor/js/test/block-supports-list.spec.js
+++ b/packages/editor/js/test/block-supports-list.spec.js
@@ -38,47 +38,49 @@ const ajv = new Ajv({ allowUnionTypes: true });
 	'textShadow',
 	'typography',
 ].forEach((support) => {
+	let supports;
+
 	switch (support) {
 		case 'background':
-			var supports = background;
+			supports = background;
 			break;
 
 		case 'border':
-			var supports = border;
+			supports = border;
 			break;
 
 		case 'boxShadow':
-			var supports = boxShadow;
+			supports = boxShadow;
 			break;
 		case 'divider':
-			var supports = divider;
+			supports = divider;
 			break;
 		case 'effects':
-			var supports = effects;
+			supports = effects;
 			break;
 		case 'layout':
-			var supports = layout;
+			supports = layout;
 			break;
 		case 'mouse':
-			var supports = mouse;
+			supports = mouse;
 			break;
 		case 'outline':
-			var supports = outline;
+			supports = outline;
 			break;
 		case 'position':
-			var supports = position;
+			supports = position;
 			break;
 		case 'size':
-			var supports = size;
+			supports = size;
 			break;
 		case 'spacing':
-			var supports = spacing;
+			supports = spacing;
 			break;
 		case 'textShadow':
-			var supports = textShadow;
+			supports = textShadow;
 			break;
 		case 'typography':
-			var supports = typography;
+			supports = typography;
 			break;
 	}
 	describe(`Validate blockera ${support} supports of Block Supports JSON`, () => {

--- a/packages/editor/php/StyleDefinitions/BaseStyleDefinition.php
+++ b/packages/editor/php/StyleDefinitions/BaseStyleDefinition.php
@@ -516,6 +516,25 @@ abstract class BaseStyleDefinition {
 	}
 
 	/**
+	 * Get supports.
+	 *
+	 * @return array
+	 */
+	protected function getStyleEngineConfig( string $support): array {
+
+		$block_type = \WP_Block_Type_Registry::get_instance()->get_registered( $this->block['blockName'] );
+
+		$default_style_engine_config = blockera_get_block_support( $this->getId(), $support, 'style-engine-config' ) ?? [];
+
+		if (! $block_type) {
+
+			return $default_style_engine_config;
+		}
+
+		return  array_merge($default_style_engine_config, $block_type->supports['blockeraStyleEngineConfig'][ $support ] ?? []);
+	}
+
+	/**
 	 * Resettings some properties to fresh before generate new styles.
 	 *
 	 * @return void
@@ -525,5 +544,4 @@ abstract class BaseStyleDefinition {
 		$this->css          = [];
 		$this->declarations = [];
 	}
-
 }

--- a/packages/editor/php/StyleDefinitions/Border.php
+++ b/packages/editor/php/StyleDefinitions/Border.php
@@ -90,18 +90,19 @@ class Border extends BaseStyleDefinition {
 				}
 				break;
 			case 'border-radius':
-				$value = $setting[ $cssProperty ];
+				$border_radius_config = $this->getStyleEngineConfig('blockeraBorderRadius');
+				$value                = $setting[ $cssProperty ];
 
 				if ( ! empty( $value['type'] ) && 'all' === $value['type'] ) {
 
-					$declaration['border-radius'] = ! empty( $value['all'] ) ? blockera_get_value_addon_real_value( $value['all'] ) : '';
+					$declaration[ $border_radius_config['all'] ] = ! empty( $value['all'] ) ? blockera_get_value_addon_real_value( $value['all'] ) : '';
 
 				} else {
 
-					$declaration['border-top-left-radius']     = ! empty( $value['topLeft'] ) ? blockera_get_value_addon_real_value( $value['topLeft'] ) : '';
-					$declaration['border-top-right-radius']    = ! empty( $value['topRight'] ) ? blockera_get_value_addon_real_value( $value['topRight'] ) : '';
-					$declaration['border-bottom-right-radius'] = ! empty( $value['bottomRight'] ) ? blockera_get_value_addon_real_value( $value['bottomRight'] ) : '';
-					$declaration['border-bottom-left-radius']  = ! empty( $value['bottomLeft'] ) ? blockera_get_value_addon_real_value( $value['bottomLeft'] ) : '';
+					$declaration[ $border_radius_config['topLeft'] ]     = ! empty( $value['topLeft'] ) ? blockera_get_value_addon_real_value( $value['topLeft'] ) : '';
+					$declaration[ $border_radius_config['topRight'] ]    = ! empty( $value['topRight'] ) ? blockera_get_value_addon_real_value( $value['topRight'] ) : '';
+					$declaration[ $border_radius_config['bottomRight'] ] = ! empty( $value['bottomRight'] ) ? blockera_get_value_addon_real_value( $value['bottomRight'] ) : '';
+					$declaration[ $border_radius_config['bottomLeft'] ]  = ! empty( $value['bottomLeft'] ) ? blockera_get_value_addon_real_value( $value['bottomLeft'] ) : '';
 				}
 				break;
 		}

--- a/packages/editor/php/helpers.php
+++ b/packages/editor/php/helpers.php
@@ -749,11 +749,11 @@ if ( ! function_exists( 'blockera_get_available_block_supports' ) ) {
 	 * @see: ../js/schemas/blockera-block-supports-list.json
 	 *
 	 * @param string $support_category the support category name.
+	 * @param string $support the support name.
 	 *
 	 * @return array The available block supports list for support category or all categories.
 	 */
-	function blockera_get_available_block_supports( string $support_category = '' ): array {
-
+	function blockera_get_available_block_supports( string $support_category = '', string $support = '' ): array {
 		$supports = [];
 		$files    = glob( blockera_core_config( 'app.vendor_path' ) . 'blockera/editor/js/schemas/block-supports/*-block-supports-list.json' );
 
@@ -765,25 +765,12 @@ if ( ! function_exists( 'blockera_get_available_block_supports' ) ) {
 
 			$support_config = json_decode( ob_get_clean(), true );
 
-			if ( empty( $support_config['supports'] ) || ( ! empty( trim( $support_category ) ) && $support_config['title'] !== $support_category ) ) {
+			if ( empty( $support_config['supports'] ) || ( ! empty( trim( $support_category ) ) && $support_config['title'] !== $support_category ) || ! isset($support_config['supports'][ $support ]) ) {
 
 				continue;
 			}
 
-			$supports = array_merge(
-				$supports,
-				blockera_array_flat(
-					array_map(
-						function ( array $support ): array {
-
-							return [
-								$support['name'] => $support,
-							];
-						},
-						$support_config['supports']
-					)
-				)
-			);
+			$supports[ $support ] = $support_config['supports'][ $support ];
 		}
 
 		return $supports;
@@ -804,7 +791,7 @@ if ( ! function_exists( 'blockera_get_block_support' ) ) {
 	function blockera_get_block_support( string $support_category, string $name, string $property = '' ) {
 
 		$support_category = \Blockera\Utils\Utils::kebabCase( $support_category );
-		$supports         = blockera_get_available_block_supports( $support_category );
+		$supports         = blockera_get_available_block_supports( $support_category, $name );
 
 		if ( empty( $supports ) || empty( $supports[ $name ] ) ) {
 


### PR DESCRIPTION
# Add Block Supports Schema Definition

## Description
This PR introduces a JSON schema definition for block supports in Blockera. The schema standardizes how block support features are defined and validated, improving developer experience and maintaining consistency across the codebase.

### Key Features
- Defines a structured schema for block supports configuration
- Includes support for feature status, fallback options, and CSS properties
- Provides style engine configuration capabilities
- Allows for developer notes and documentation
- Ensures backwards compatibility through fallback identifiers

## Implementation Details
- Added `block.supports.schema.json` to define the structure of block supports
- Schema validates:
  - Support status (boolean)
  - Fallback options (array or string)
  - CSS property mapping
  - Style engine configuration
  - Developer notes

## Testing Instructions
1. Validate block support configurations against the schema
2. Test with both new and existing block supports
3. Verify fallback support for backwards compatibility
4. Check style engine configuration integration

## Documentation
The schema is self-documenting with detailed property descriptions. Key properties:
- `supports`: Root object containing all block support definitions
- `status`: Boolean flag for feature availability
- `fallback`: Backwards compatibility identifiers
- `css-property`: Standard CSS property mapping
- `style-engine-config`: Style engine specific configuration
- `note`: Developer documentation field

## Related Issues
- Relates to block support standardization
- Improves developer tooling and validation

---
Please review and provide feedback on the schema structure and documentation.