### PR TITLE
Fix: Flex child block section not showing for 9 blocks

### DIFF
--- a/packages/blocks/core/CHANGELOG.md
+++ b/packages/blocks/core/CHANGELOG.md
@@ -1,6 +1,12 @@
 ## Unreleased
 
-### New Features:
+### Bug Fixes
+- Flex child block section not showing for child blocks of 9 blocks (e.g. `Columns`, `Buttons`, `Social Links` and etc.).
+
+
+## 1.0.0 (2024-12-08)
+
+### New Features
 - Added `Spacer Block` support by Blockera. [[🔗 Link](https://community.blockera.ai/feature-request-1rsjg2ck/post/spacer-block-support-pritFhuc8gbsXko)]
 - Added support for the `Navigation Link Block` by Blockera. [[🔗 Link](https://community.blockera.ai/feature-request-1rsjg2ck/post/supporting-blocks-inside-navigation-block-MIcY979kIVCxkvU)]
 - Added support for the `Home Link Block` by Blockera. [[🔗 Link](https://community.blockera.ai/feature-request-1rsjg2ck/post/supporting-blocks-inside-navigation-block-MIcY979kIVCxkvU)]

--- a/packages/blocks/core/js/wordpress/buttons/test/block-attributes.blocks.e2e.cy.js
+++ b/packages/blocks/core/js/wordpress/buttons/test/block-attributes.blocks.e2e.cy.js
@@ -22,16 +22,10 @@ describe('Testing core/buttons block registered default attributes value', () =>
 		getWPDataObject().then((data) => {
 			const attributes = getBlockType(data, 'core/buttons').attributes;
 
-			// Assertion for sync registered default "blockeraDisplay" value with type!
-			expect(
-				attributes?.blockeraDisplay?.type ===
-					typeof attributes?.blockeraDisplay?.default
-			).to.be.equal(true);
-
 			// Assertion for sync registered default "blockeraDisplay" value with selected block "blockeraDisplay" value.
-			expect(attributes?.blockeraDisplay?.default).to.be.deep.equal(
-				getSelectedBlock(data, 'blockeraDisplay')
-			);
+			expect(
+				attributes?.blockeraDisplay?.default?.value
+			).to.be.deep.equal(getSelectedBlock(data, 'blockeraDisplay'));
 		});
 	});
 });

--- a/packages/blocks/core/js/wordpress/columns/test/block-attributes.blocks.e2e.cy.js
+++ b/packages/blocks/core/js/wordpress/columns/test/block-attributes.blocks.e2e.cy.js
@@ -22,16 +22,10 @@ describe('Testing core/columns block registered default attributes value', () =>
 		getWPDataObject().then((data) => {
 			const attributes = getBlockType(data, 'core/columns').attributes;
 
-			// Assertion for sync registered default "blockeraDisplay" value with type!
-			expect(
-				attributes?.blockeraDisplay?.type ===
-					typeof attributes?.blockeraDisplay?.default
-			).to.be.equal(true);
-
 			// Assertion for sync registered default "blockeraDisplay" value with selected block "blockeraDisplay" value.
-			expect(attributes?.blockeraDisplay?.default).to.be.deep.equal(
-				getSelectedBlock(data, 'blockeraDisplay')
-			);
+			expect(
+				attributes?.blockeraDisplay?.default?.value
+			).to.be.deep.equal(getSelectedBlock(data, 'blockeraDisplay'));
 		});
 	});
 });

--- a/packages/blocks/core/js/wordpress/comments-pagination/test/block-attributes.blocks.e2e.cy.js
+++ b/packages/blocks/core/js/wordpress/comments-pagination/test/block-attributes.blocks.e2e.cy.js
@@ -33,16 +33,10 @@ describe('Testing core/comments-pagination block registered default attributes v
 				'core/comments-pagination'
 			).attributes;
 
-			// Assertion for sync registered default "blockeraDisplay" value with type!
-			expect(
-				attributes?.blockeraDisplay?.type ===
-					typeof attributes?.blockeraDisplay?.default
-			).to.be.equal(true);
-
 			// Assertion for sync registered default "blockeraDisplay" value with selected block "blockeraDisplay" value.
-			expect(attributes?.blockeraDisplay?.default).to.be.deep.equal(
-				getSelectedBlock(data, 'blockeraDisplay')
-			);
+			expect(
+				attributes?.blockeraDisplay?.default?.value
+			).to.be.deep.equal(getSelectedBlock(data, 'blockeraDisplay'));
 		});
 	});
 });

--- a/packages/blocks/core/js/wordpress/gallery/test/block-attributes.blocks.e2e.cy.js
+++ b/packages/blocks/core/js/wordpress/gallery/test/block-attributes.blocks.e2e.cy.js
@@ -22,16 +22,10 @@ describe('Testing core/gallery block registered default attributes value', () =>
 		getWPDataObject().then((data) => {
 			const attributes = getBlockType(data, 'core/gallery').attributes;
 
-			// Assertion for sync registered default "blockeraDisplay" value with type!
-			expect(
-				attributes?.blockeraDisplay?.type ===
-					typeof attributes?.blockeraDisplay?.default
-			).to.be.equal(true);
-
 			// Assertion for sync registered default "blockeraDisplay" value with selected block "blockeraDisplay" value.
-			expect(attributes?.blockeraDisplay?.default).to.be.deep.equal(
-				getSelectedBlock(data, 'blockeraDisplay')
-			);
+			expect(
+				attributes?.blockeraDisplay?.default?.value
+			).to.be.deep.equal(getSelectedBlock(data, 'blockeraDisplay'));
 		});
 	});
 });

--- a/packages/blocks/core/php/woocommerce/mini-cart-footer-block/block.php
+++ b/packages/blocks/core/php/woocommerce/mini-cart-footer-block/block.php
@@ -15,7 +15,9 @@ return array_merge(
 			[
 				'blockeraDisplay' => [
 					'type'    => 'string',
-					'default' => 'flex',
+					'default' => [
+						'value' => 'flex',
+					],
 				],
 			]
 		),

--- a/packages/blocks/core/php/woocommerce/product-template/block.php
+++ b/packages/blocks/core/php/woocommerce/product-template/block.php
@@ -15,7 +15,9 @@ return array_merge(
 			[
 				'blockeraDisplay' => [
 					'type'    => 'string',
-					'default' => 'flex',
+					'default' => [
+						'value' => 'flex',
+					],
 				],
 			]
 		),

--- a/packages/blocks/core/php/wordpress/buttons/block.php
+++ b/packages/blocks/core/php/wordpress/buttons/block.php
@@ -15,7 +15,9 @@ return array_merge(
 			[
 				'blockeraDisplay' => [
 					'type'    => 'string',
-					'default' => 'flex',
+					'default' => [
+						'value' => 'flex',
+					],
 				],
 			]
 		),

--- a/packages/blocks/core/php/wordpress/columns/block.php
+++ b/packages/blocks/core/php/wordpress/columns/block.php
@@ -15,7 +15,9 @@ return array_merge(
 			[
 				'blockeraDisplay' => [
 					'type'    => 'string',
-					'default' => 'flex',
+					'default' => [
+						'value' => 'flex',
+					],
 				],
 			]
 		),

--- a/packages/blocks/core/php/wordpress/comments-pagination/block.php
+++ b/packages/blocks/core/php/wordpress/comments-pagination/block.php
@@ -15,7 +15,9 @@ return array_merge(
 			[
 				'blockeraDisplay' => [
 					'type'    => 'string',
-					'default' => 'flex',
+					'default' => [
+						'value' => 'flex',
+					],
 				],
 			]
 		),

--- a/packages/blocks/core/php/wordpress/gallery/block.php
+++ b/packages/blocks/core/php/wordpress/gallery/block.php
@@ -15,7 +15,9 @@ return array_merge(
 			[
 				'blockeraDisplay' => [
 					'type'    => 'string',
-					'default' => 'flex',
+					'default' => [
+						'value' => 'flex',
+					],
 				],
 			]
 		),

--- a/packages/blocks/core/php/wordpress/post-author/block.php
+++ b/packages/blocks/core/php/wordpress/post-author/block.php
@@ -15,7 +15,9 @@ return array_merge(
 			[
 				'blockeraDisplay' => [
 					'type'    => 'string',
-					'default' => 'flex',
+					'default' => [
+						'value' => 'flex',
+					],
 				],
 			]
 		),

--- a/packages/blocks/core/php/wordpress/query-pagination/block.php
+++ b/packages/blocks/core/php/wordpress/query-pagination/block.php
@@ -15,7 +15,9 @@ return array_merge(
 			[
 				'blockeraDisplay' => [
 					'type'    => 'string',
-					'default' => 'flex',
+					'default' => [
+						'value' => 'flex',
+					],
 				],
 			]
 		),

--- a/packages/blocks/core/php/wordpress/social-links/block.php
+++ b/packages/blocks/core/php/wordpress/social-links/block.php
@@ -15,7 +15,9 @@ return array_merge(
 			[
 				'blockeraDisplay' => [
 					'type'    => 'string',
-					'default' => 'flex',
+					'default' => [
+						'value' => 'flex',
+					],
 				],
 			]
 		),


### PR DESCRIPTION
The Flex Child block section is now showing for following blocks and needs to be fixed:

- mini-cart-footer
- product-template
- buttons
- columns
- comments-pagination
- gallery
- post-author
- query-pagination
- social-links