### PR TITLE
Feat: Input Control UX Improvements

### DIFF
--- a/packages/controls/CHANGELOG.md
+++ b/packages/controls/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### New Features
+- Added dynamic unit switching in input controls - Users can now change units by typing them directly (e.g., typing "12px" or "12%" automatically updates both value and unit) [[🔗 Bug](https://community.blockera.ai/feature-request-1rsjg2ck/post/support-changing-the-unit-of-input-by-typing-it-nVKjZXQKHGTN4Da)]
+- Added Shift key modifier for input controls - Hold Shift while using arrow keys to increment/decrement values by 10 instead of 1, enabling faster value adjustments.
+
 ### Improvements
 - Update border radius control to improve the user experience (UX).
 - Update border control to improve the user experience (UX).

--- a/packages/controls/js/libs/input-control/components/input-arrows.js
+++ b/packages/controls/js/libs/input-control/components/input-arrows.js
@@ -1,0 +1,91 @@
+// @flow
+/**
+ * External dependencies
+ */
+import type { MixedElement } from 'react';
+
+/**
+ * Blockera dependencies
+ */
+import { controlClassNames } from '@blockera/classnames';
+import { isEmpty } from '@blockera/utils';
+
+/**
+ * Internal dependencies
+ */
+import { default as ArrowUpIcon } from '../icons/arrow-up';
+import { default as ArrowDownIcon } from '../icons/arrow-down';
+
+export function InputArrows({
+	value,
+	setValue,
+	disabled,
+	min,
+	max,
+	size,
+}: {
+	value: string | number,
+	setValue: (value: number) => void,
+	disabled?: boolean,
+	min?: number,
+	max?: number,
+	size?: string,
+}): MixedElement {
+	if (['extra-small'].includes(size)) {
+		return null;
+	}
+
+	return (
+		<div
+			className={controlClassNames(
+				'input-arrows',
+				disabled && 'is-disabled'
+			)}
+			data-test="arrows-container"
+		>
+			<span
+				className={controlClassNames(
+					'input-arrow',
+					'input-arrow-up',
+					!isEmpty(max) && +value >= +max ? 'is-disabled' : ''
+				)}
+				onClick={() => {
+					if (disabled) return;
+					let newValue = !isEmpty(value) ? +value : 0;
+					newValue += 1;
+
+					if (!isEmpty(max) && newValue > +max) {
+						newValue = +max;
+					}
+
+					setValue(newValue);
+				}}
+				data-test="arrow-up"
+			>
+				<ArrowUpIcon />
+			</span>
+
+			<span
+				className={controlClassNames(
+					'input-arrow',
+					'input-arrow-down',
+					!isEmpty(min) && +value <= +min ? 'is-disabled' : ''
+				)}
+				onClick={() => {
+					if (disabled) return;
+					let newValue = !isEmpty(value) ? +value : 0;
+					newValue -= 1;
+
+					if (!isEmpty(min) && newValue <= +min) {
+						newValue = +min;
+					}
+
+					setValue(newValue);
+				}}
+				data-test="arrow-down"
+			>
+				<ArrowDownIcon />
+			</span>
+		</div>
+	);
+}

--- a/packages/controls/js/libs/input-control/components/number-input.js
+++ b/packages/controls/js/libs/input-control/components/number-input.js
@@ -24,8 +24,7 @@ import {
  */
 import { RangeControl } from '../../index';
 import type { InnerInputControlProps } from '../types';
-import { default as ArrowUpIcon } from '../icons/arrow-up';
-import { default as ArrowDownIcon } from '../icons/arrow-down';
+import { InputArrows } from './input-arrows';
 
 export function NumberInput({
 	value,
@@ -212,76 +211,19 @@ export function NumberInput({
 				{...getDragEvent()}
 			/>
 
+			{arrows && (
+				<InputArrows
+					value={value}
+					setValue={setValue}
+					disabled={disabled}
+					min={min}
+					max={max}
+					size={size}
+				/>
+			)}
+
 			<div className={controlInnerClassNames('input-actions')}>
 				{actions}
-
-				{arrows && size !== 'extra-small' && (
-					<div
-						className={controlClassNames(
-							'input-arrows',
-							disabled && 'is-disabled'
-						)}
-						data-test="arrows-container"
-					>
-						<span
-							className={controlClassNames(
-								'input-arrow',
-								'input-arrow-up',
-								!isEmpty(maxValue?.max) &&
-									+value >= +maxValue.max
-									? 'is-disabled'
-									: ''
-							)}
-							onClick={() => {
-								let newValue = !isEmpty(value) ? +value : 0;
-
-								newValue += 1;
-
-								// don't let user set value bigger than max value
-								if (
-									!isEmpty(maxValue?.max) &&
-									newValue > +maxValue.max
-								) {
-									newValue = +maxValue.max;
-								}
-
-								setValue(newValue);
-							}}
-							data-test="arrow-up"
-						>
-							<ArrowUpIcon />
-						</span>
-
-						<span
-							className={controlClassNames(
-								'input-arrow',
-								'input-arrow-down',
-								!isEmpty(minValue?.min) &&
-									+value <= +minValue.min
-									? 'is-disabled'
-									: ''
-							)}
-							onClick={() => {
-								let newValue = !isEmpty(value) ? +value : 0;
-
-								newValue -= 1;
-
-								// don't let user set value bigger than max value
-								if (
-									!isEmpty(minValue?.min) &&
-									newValue <= +minValue?.min
-								) {
-									newValue = +minValue?.min;
-								}
-
-								setValue(newValue);
-							}}
-							data-test="arrow-down"
-						>
-							<ArrowDownIcon />
-						</span>
-					</div>
-				)}
 			</div>
 
 			{children}

--- a/packages/controls/js/libs/input-control/components/unit-input.js
+++ b/packages/controls/js/libs/input-control/components/unit-input.js
@@ -279,8 +279,8 @@ export function UnitInput({
 				let incrementedValue = currentValue + increment;
 
 				// Check max constraint
-				if (!isEmpty(max) && incrementedValue > max) {
-					incrementedValue = max;
+				if (!isEmpty(max) && incrementedValue > Number(max)) {
+					incrementedValue = Number(max);
 				}
 
 				setTypedValue(String(incrementedValue));
@@ -297,8 +297,8 @@ export function UnitInput({
 				let decrementedValue = currentValue - increment;
 
 				// Check min constraint
-				if (!isEmpty(min) && decrementedValue < min) {
-					decrementedValue = min;
+				if (!isEmpty(min) && decrementedValue < Number(min)) {
+					decrementedValue = Number(min);
 				}
 
 				setTypedValue(String(decrementedValue));

--- a/packages/controls/js/libs/input-control/components/unit-input.scss
+++ b/packages/controls/js/libs/input-control/components/unit-input.scss
@@ -62,13 +62,11 @@
 				text-align: right;
 			}
 		}
-
 	}
 
 	&.blockera-control-unit-special {
 
 		.blockera-control-unit-select {
-
 			display: block;
 			width: 100%;
 			height: 30px;
@@ -85,49 +83,35 @@
 			letter-spacing: 0;
 
 			&:hover {
-
 				border-color: var(--blockera-controls-border-color-hover);
-
 			}
 
 			&:focus {
-
 				border-color: var(--blockera-controls-primary-color);
 				box-shadow: 0 0 0 1px var(--blockera-controls-primary-color);
-
 			}
 
 			&:not(:disabled):hover {
-
 				background-color: var(--blockera-controls-background-color);
-
 			}
 
 			&.hide-arrow {
-
 				background: transparent;
-
 			}
-
 		}
-
 	}
 
 	&.blockera-control-unit-func {
 
 		.blockera-control-input-tag {
-
 			padding-right: 65px;
 			white-space: nowrap;
 			overflow: hidden;
 			text-overflow: ellipsis;
-
 		}
-
 	}
 
 	.components-button.blockera-component-button.blockera-control-maximise-btn {
-
 		font-size: 11px;
 		color: var(--blockera-controls-placeholder-color);
 		padding: 0;
@@ -139,25 +123,18 @@
 		margin-right: 2px;
 
 		&:hover:not(.is-open-popover) {
-
 			color: var(--blockera-controls-color);
-
 		}
 
 		&.is-focused {
-
 			color: var(--blockera-controls-primary-color);
-
 		}
 
 		&.is-open-popover {
-
 			color: #ffffff;
 			background: var(--blockera-controls-primary-color) !important;
 			box-shadow: none;
-
 		}
-
 	}
 
 	.input-tag-placeholder {
@@ -172,8 +149,21 @@
 	&.is-focused {
 
 		.input-tag-placeholder {
-
 			color: var(--blockera-controls-primary-color);
+		}
+	}
+
+	&.is-disabled {
+		opacity: 0.6;
+		cursor: not-allowed;
+		pointer-events: none;
+
+		input,
+		select,
+		.input-tag-placeholder,
+		.maximise-btn {
+			cursor: not-allowed;
+			pointer-events: none;
 		}
 	}
 }

--- a/packages/controls/js/libs/input-control/test/input-control.cy.js
+++ b/packages/controls/js/libs/input-control/test/input-control.cy.js
@@ -646,7 +646,7 @@ describe('input control component testing', () => {
 		});
 
 		describe('Range', () => {
-			it('should render arrows and work', () => {
+			it('should render range and work', () => {
 				const name = nanoid();
 				cy.withDataProvider({
 					component: (
@@ -738,6 +738,94 @@ describe('input control component testing', () => {
 					return expect(getControlValue(name)).to.eq('');
 				});
 			});
+
+			it('should handle typing units directly', () => {
+				const name = nanoid();
+				cy.withDataProvider({
+					component: <InputControl unitType="general" />,
+					name,
+				});
+
+				cy.get('input').focus();
+				cy.get('input').type('10px');
+
+				// Wait for unit update timeout
+				cy.wait(350);
+
+				cy.get('input').should('have.value', '10');
+				cy.get('[aria-label="Select Unit"]').should('have.value', 'px');
+				cy.then(() => {
+					return expect(getControlValue(name)).to.eq('10px');
+				});
+
+				cy.get('input').clear();
+				cy.get('input').type('20%');
+
+				// Wait for unit update timeout
+				cy.wait(350);
+
+				cy.get('input').should('have.value', '20');
+				cy.get('[aria-label="Select Unit"]').should('have.value', '%');
+				cy.then(() => {
+					return expect(getControlValue(name)).to.eq('20%');
+				});
+			});
+
+			it('should handle pasting units', () => {
+				const name = nanoid();
+				cy.withDataProvider({
+					component: <InputControl unitType="general" />,
+					name,
+				});
+
+				// Test pasting with unit
+				cy.get('input').focus();
+				cy.get('input')
+					.invoke('val', '30rem')
+					.trigger('paste', {
+						clipboardData: {
+							getData: () => '30rem',
+						},
+					});
+
+				cy.get('input').should('have.value', '30');
+				cy.get('[aria-label="Select Unit"]').should(
+					'have.value',
+					'rem'
+				);
+				cy.then(() => {
+					return expect(getControlValue(name)).to.eq('30rem');
+				});
+			});
+
+			it('should allow typing complete units with delay', () => {
+				const name = nanoid();
+				cy.withDataProvider({
+					component: <InputControl unitType="general" />,
+					name,
+				});
+
+				cy.get('input').focus();
+
+				// Type each character with a delay
+				cy.get('input').type('1');
+				cy.get('input').type('0');
+				cy.get('input').type('r');
+				cy.get('input').type('e');
+				cy.get('input').type('m');
+
+				// Wait for unit update timeout
+				cy.wait(300);
+
+				cy.get('input').should('have.value', '10');
+				cy.get('[aria-label="Select Unit"]').should(
+					'have.value',
+					'rem'
+				);
+				cy.then(() => {
+					return expect(getControlValue(name)).to.eq('10rem');
+				});
+			});
 		});
 
 		describe('Units', () => {
@@ -813,7 +901,7 @@ describe('input control component testing', () => {
 					value: '12px',
 				});
 
-				cy.get('input[type=number]').should('be.disabled');
+				cy.get('input[type=text]').should('be.disabled');
 				cy.get('select').should('be.disabled');
 			});
 
@@ -1103,62 +1191,6 @@ describe('input control component testing', () => {
 					'Invalid'
 				);
 			});
-
-			// todo this feature currently has not been implemented
-			// it('custom unit with string format', () => {
-			// 	const name = nanoid();
-			// 	cy.withDataProvider({
-			// 		component: (
-			// 			<InputControl
-			// 				type="number"
-			// 				units={[
-			// 					{
-			// 						value: 'px',
-			// 						label: 'PX',
-			// 						format: 'number',
-			// 					},
-			// 					{
-			// 						value: 'em',
-			// 						label: 'EM',
-			// 						format: 'number',
-			// 					},
-			// 					{
-			// 						value: '%',
-			// 						label: '%',
-			// 						format: 'number',
-			// 					},
-			// 					{
-			// 						value: 'XYZ',
-			// 						label: 'XYZ',
-			// 						format: 'string',
-			// 					},
-			// 				]}
-			// 			/>
-			// 		),
-			// 		name,
-			// 		value: '0px',
-			// 	});
-			//
-			// 	// set special value
-			// 	cy.get('[aria-label="Select Unit"]').select('XYZ');
-			// 	cy.get('[aria-label="Select Unit"]').should(
-			// 		'have.value',
-			// 		'XYZ'
-			// 	);
-			// 	cy.then(() => {
-			// 		return expect(getControlValue(name)).to.eq('0XYZ');
-			// 	});
-			// 	cy.get('input').should('have.value', 0);
-			//
-			// 	// change to custom unit and type string
-			// 	cy.get('input').clear();
-			// 	cy.get('input').focus();
-			// 	cy.get('input').type('text value');
-			// 	cy.get('input').should('have.value', 'text value');
-			// 	cy.then(() => {
-			// 		return expect(getControlValue(name)).to.eq('text valueXYZ');
-			// 	});
-			// });
 		});
 
 		describe('CSS Func Value', () => {
@@ -1279,7 +1311,7 @@ describe('input control component testing', () => {
 		});
 
 		describe('Range', () => {
-			it('should render arrows and work', () => {
+			it('should render range and work', () => {
 				const name = nanoid();
 				cy.withDataProvider({
 					component: (
@@ -1297,7 +1329,7 @@ describe('input control component testing', () => {
 
 				cy.get('input[type=range]').setSliderValue(-20);
 				cy.getByDataTest('range-control').should('have.value', '-20');
-				cy.get('input[type=number]').should('have.value', -20);
+				cy.get('input[type=text]').should('have.value', -20);
 				cy.then(() => {
 					return expect(getControlValue(name)).to.eq('-20px');
 				});
@@ -1305,14 +1337,14 @@ describe('input control component testing', () => {
 				// should set to -50 because -100 is smaller than min value
 				cy.get('input[type=range]').setSliderValue(-100);
 				cy.getByDataTest('range-control').should('have.value', '-50');
-				cy.get('input[type=number]').should('have.value', -50);
+				cy.get('input[type=text]').should('have.value', -50);
 				cy.then(() => {
 					return expect(getControlValue(name)).to.eq('-50px');
 				});
 
 				cy.get('input[type=range]').setSliderValue(20);
 				cy.getByDataTest('range-control').should('have.value', '20');
-				cy.get('input[type=number]').should('have.value', 20);
+				cy.get('input[type=text]').should('have.value', 20);
 				cy.then(() => {
 					return expect(getControlValue(name)).to.eq('20px');
 				});
@@ -1320,7 +1352,7 @@ describe('input control component testing', () => {
 				// should set to 50 because 100 is smaller than min value
 				cy.get('input[type=range]').setSliderValue(100);
 				cy.getByDataTest('range-control').should('have.value', '50');
-				cy.get('input[type=number]').should('have.value', 50);
+				cy.get('input[type=text]').should('have.value', 50);
 				cy.then(() => {
 					return expect(getControlValue(name)).to.eq('50px');
 				});

--- a/packages/controls/js/libs/input-control/test/input-control.cy.js
+++ b/packages/controls/js/libs/input-control/test/input-control.cy.js
@@ -1464,6 +1464,201 @@ describe('input control component testing', () => {
 				cy.get('input').should('have.value', 9);
 				cy.get('input').should('have.class', 'invalid');
 
+				describe('Keyboard Arrows', () => {
+					it('should handle arrow up/down keys when input is focused', () => {
+						const name = nanoid();
+						cy.withDataProvider({
+							component: <InputControl unitType="general" />,
+							name,
+							value: '10px',
+						});
+
+						// Test arrow up
+						cy.get('input').focus();
+						cy.get('input').trigger('keydown', { key: 'ArrowUp' });
+						cy.get('input').should('have.value', '11');
+						cy.then(() => {
+							return expect(getControlValue(name)).to.eq('11px');
+						});
+
+						// Test arrow up
+						cy.get('input').focus();
+						cy.get('input').trigger('keydown', { key: 'ArrowUp' });
+						cy.get('input').should('have.value', '12');
+						cy.then(() => {
+							return expect(getControlValue(name)).to.eq('12px');
+						});
+
+						// Test arrow down
+						cy.get('input').trigger('keydown', {
+							key: 'ArrowDown',
+						});
+						cy.get('input').should('have.value', '11');
+						cy.then(() => {
+							return expect(getControlValue(name)).to.eq('11px');
+						});
+
+						// Test arrow down
+						cy.get('input').trigger('keydown', {
+							key: 'ArrowDown',
+						});
+						cy.get('input').should('have.value', '10');
+						cy.then(() => {
+							return expect(getControlValue(name)).to.eq('10px');
+						});
+					});
+
+					it('should respect min/max constraints with keyboard arrows', () => {
+						const name = nanoid();
+						cy.withDataProvider({
+							component: (
+								<InputControl
+									unitType="general"
+									min={0}
+									max={3}
+								/>
+							),
+							name,
+							value: '2px',
+						});
+
+						// Test max constraint
+						cy.get('input').focus();
+						cy.get('input').trigger('keydown', { key: 'ArrowUp' }); // 3
+						cy.get('input').trigger('keydown', { key: 'ArrowUp' }); // Should stay at 3
+						cy.get('input').should('have.value', '3');
+						cy.then(() => {
+							return expect(getControlValue(name)).to.eq('3px');
+						});
+
+						// Test min constraint
+						cy.get('input').trigger('keydown', {
+							key: 'ArrowDown',
+						}); // 2
+						cy.get('input').trigger('keydown', {
+							key: 'ArrowDown',
+						}); // 1
+						cy.get('input').trigger('keydown', {
+							key: 'ArrowDown',
+						}); // 0
+						cy.get('input').trigger('keydown', {
+							key: 'ArrowDown',
+						}); // Should stay at 0
+						cy.get('input').should('have.value', '0');
+						cy.then(() => {
+							return expect(getControlValue(name)).to.eq('0px');
+						});
+					});
+
+					it('should not respond to arrow keys when disabled', () => {
+						const name = nanoid();
+						cy.withDataProvider({
+							component: (
+								<InputControl
+									unitType="general"
+									disabled={true}
+								/>
+							),
+							name,
+							value: '10px',
+						});
+
+						cy.get('input').trigger('keydown', {
+							key: 'ArrowUp',
+							force: true,
+						});
+						cy.get('input').should('have.value', '10');
+						cy.then(() => {
+							return expect(getControlValue(name)).to.eq('10px');
+						});
+					});
+
+					it('should handle shift + arrow keys for larger increments', () => {
+						const name = nanoid();
+						cy.withDataProvider({
+							component: <InputControl unitType="general" />,
+							name,
+							value: '20px',
+						});
+
+						// Test shift + arrow up
+						cy.get('input').focus();
+						cy.get('input').trigger('keydown', {
+							key: 'ArrowUp',
+							shiftKey: true,
+						});
+						cy.get('input').should('have.value', '30');
+						cy.then(() => {
+							return expect(getControlValue(name)).to.eq('30px');
+						});
+
+						// Test shift + arrow down
+						cy.get('input').trigger('keydown', {
+							key: 'ArrowDown',
+							shiftKey: true,
+						});
+						cy.get('input').should('have.value', '20');
+						cy.then(() => {
+							return expect(getControlValue(name)).to.eq('20px');
+						});
+
+						// Test combination of regular and shift arrows
+						cy.get('input').trigger('keydown', { key: 'ArrowUp' }); // Regular +1
+						cy.get('input').trigger('keydown', {
+							key: 'ArrowUp',
+							shiftKey: true,
+						}); // Shift +10
+						cy.get('input').should('have.value', '31');
+						cy.then(() => {
+							return expect(getControlValue(name)).to.eq('31px');
+						});
+					});
+
+					it('should respect min/max constraints with shift + arrow keys', () => {
+						const name = nanoid();
+						cy.withDataProvider({
+							component: (
+								<InputControl
+									unitType="general"
+									min={0}
+									max={25}
+								/>
+							),
+							name,
+							value: '20px',
+						});
+
+						// Test max constraint with shift
+						cy.get('input').focus();
+						cy.get('input').trigger('keydown', {
+							key: 'ArrowUp',
+							shiftKey: true,
+						}); // Would be 30, but max is 25
+						cy.get('input').should('have.value', '25');
+						cy.then(() => {
+							return expect(getControlValue(name)).to.eq('25px');
+						});
+
+						// Test min constraint with shift
+						cy.get('input').trigger('keydown', {
+							key: 'ArrowDown',
+							shiftKey: true,
+						}); // 15
+						cy.get('input').trigger('keydown', {
+							key: 'ArrowDown',
+							shiftKey: true,
+						}); // 5
+						cy.get('input').trigger('keydown', {
+							key: 'ArrowDown',
+							shiftKey: true,
+						}); // Would be -5, but min is 0
+						cy.get('input').should('have.value', '0');
+						cy.then(() => {
+							return expect(getControlValue(name)).to.eq('0px');
+						});
+					});
+				});
+
 				cy.get('input').clear();
 				cy.get('input').type('10');
 				cy.get('input').should('have.value', 10);


### PR DESCRIPTION
- [ ] [change unit dynamically by typing unit](https://community.blockera.ai/feature-request-1rsjg2ck/post/support-changing-the-unit-of-input-by-typing-it-nVKjZXQKHGTN4Da)
- [ ] Support for unit change while pasting text
- [ ] Support for arrow up and down key to change value
- [ ] Support for shift key while arrow up and down keys for larger value change
- [ ] Improve Copy on input to append the unit to copied text
- [ ] improve negative values functionality
- [ ] Improve all tests related to input to make sure better stable control in future