### PR TITLE
Feat: Shortcut to open variable picker by typing "--" (UX Improvement)

### DIFF
--- a/packages/controls/CHANGELOG.md
+++ b/packages/controls/CHANGELOG.md
@@ -26,6 +26,7 @@
 ### Automated Tests
 - Added comprehensive test coverage for input controls, including number inputs, unit selection, keyboard navigation, and copy/paste functionality.
 - Added complete test for input control calculation feature.
+- Added test to check opening variable picker by typing "--".
 
 ## 1.0.2 (2025-02-03)
 

--- a/packages/controls/js/libs/input-control/components/unit-input.js
+++ b/packages/controls/js/libs/input-control/components/unit-input.js
@@ -46,12 +46,13 @@ export function UnitInput({
 	unitValue,
 	inputValue,
 	isValidValue,
-
+	onVariableShortcut,
 	...props
 }: {
 	...InputControlProps,
 	inputValue: string,
 	unitValue: Object,
+	onVariableShortcut: () => void,
 }): MixedElement {
 	const [isMaximizeVisible, setIsMaximizeVisible] = useState(false);
 	const [typedValue, setTypedValue] = useState(inputValue);
@@ -69,6 +70,12 @@ export function UnitInput({
 		// First check if the value is just a minus sign or minus zero
 		if (value === '-' || value === '-0') {
 			// Allow typing minus sign even if min is >= 0, we'll validate on blur
+			return;
+		}
+
+		// Special case for "--" to open variable picker
+		if (onVariableShortcut && value.endsWith('--')) {
+			onVariableShortcut();
 			return;
 		}
 

--- a/packages/controls/js/libs/input-control/index.js
+++ b/packages/controls/js/libs/input-control/index.js
@@ -89,6 +89,7 @@ export default function InputControl({
 		isSetValueAddon,
 		ValueAddonControl,
 		ValueAddonPointer,
+		valueAddonControlProps,
 	} = useValueAddon({
 		types: controlAddonTypes,
 		value,
@@ -201,6 +202,15 @@ export default function InputControl({
 					arrows={arrows}
 					size={size}
 					children={children}
+					onVariableShortcut={
+						variableTypes && variableTypes.length > 0
+							? () => {
+									valueAddonControlProps.setOpen(
+										'var-picker'
+									);
+							  }
+							: undefined
+					}
 					onChange={(newValue: ContextUnitInput): void => {
 						const { inputValue, unitValue } = newValue;
 

--- a/packages/controls/js/value-addons/test/value-addon.e2e.cy.js
+++ b/packages/controls/js/value-addons/test/value-addon.e2e.cy.js
@@ -1,0 +1,56 @@
+/**
+ * Blockera dependencies
+ */
+import { createPost } from '@blockera/dev-cypress/js/helpers';
+
+describe('Value Addon → Functionality', () => {
+	beforeEach(() => {
+		createPost();
+	});
+
+	describe('General Functionalities', () => {
+		it('Open and pick variable', () => {
+			cy.getBlock('default').type('This is test paragraph', { delay: 0 });
+			cy.getByDataTest('style-tab').click();
+
+			cy.getParentContainer('Width').within(() => {
+				cy.openValueAddon();
+			});
+
+			// select variable
+			cy.selectValueAddonItem('contentSize');
+
+			// Check block
+			cy.getIframeBody().within(() => {
+				cy.get('#blockera-styles-wrapper')
+					.invoke('text')
+					.should(
+						'include',
+						'width: var(--wp--style--global--content-size)'
+					);
+			});
+		});
+
+		it('Open value addon by typing "--"', () => {
+			cy.getBlock('default').type('This is test paragraph', { delay: 0 });
+			cy.getByDataTest('style-tab').click();
+
+			cy.getParentContainer('Width').within(() => {
+				cy.get('input').type('--');
+			});
+
+			// select variable
+			cy.selectValueAddonItem('contentSize');
+
+			// Check block
+			cy.getIframeBody().within(() => {
+				cy.get('#blockera-styles-wrapper')
+					.invoke('text')
+					.should(
+						'include',
+						'width: var(--wp--style--global--content-size)'
+					);
+			});
+		});
+	});
+});


### PR DESCRIPTION
- [x] [Shortcut to open variable picker by typing two dashes](https://community.blockera.ai/feature-request-1rsjg2ck/post/opening-variable-picker-by-typing----on-inputs-YVpltsn45tTbDyw)
- [x] E2E test to check functionality