### PR TITLE
CI: Add .pr-wp-env.json support to enable running test for specific WP versions like RC versions

### DIFF
--- a/.github/workflows/build-plugin-zip-tests.yml
+++ b/.github/workflows/build-plugin-zip-tests.yml
@@ -45,14 +45,33 @@ jobs:
                   unzip blockera.zip -d ./build/blockera
                   rm -rf blockera.zip
 
+            - name: Check if .pr-wp-env.json exists
+              id: check_wp_env_file
+              run: |
+                  if [ -f ".pr-wp-env.json" ]; then
+                    echo "Found .pr-wp-env.json"
+                    echo "wp_env_file=true" >> $GITHUB_ENV
+                  else
+                    echo "wp_env_file=false" >> $GITHUB_ENV
+                  fi
+
             - name: Create Requirements
               run: |
                   cd ./build/blockera
                   mkdir packages
                   mkdir packages/blockera
                   mkdir packages/blockera/tests
-                  touch .wp-env.json
-                  echo '{"plugins": ["."], "config": {"BLOCKERA_TELEMETRY_OPT_IN_OFF": true}, "phpVersion": "${{ matrix.php }}"}' >> .wp-env.json
+
+                  if [ "${{ env.wp_env_file }}" == "true" ]; then
+                    # Copy and modify PR wp-env config
+                    cp ../../.pr-wp-env.json .wp-env.json
+                    # Update PHP version and ensure telemetry is configured
+                    jq --arg php "${{ matrix.php }}" '. + {"phpVersion": $php} | .config.BLOCKERA_TELEMETRY_OPT_IN_OFF = true' .wp-env.json > tmp.json && mv tmp.json .wp-env.json
+                  else
+                    # Use default configuration
+                    echo '{"plugins": ["."], "config": {"BLOCKERA_TELEMETRY_OPT_IN_OFF": true}, "phpVersion": "${{ matrix.php }}"}' >> .wp-env.json
+                  fi
+
                   cat .wp-env.json
                   touch cypress.env.json
                   echo '{"isLogin": false,"wpUsername": "admin","wpPassword": "password","testURL": "http://localhost:8888","e2e": {"excludeSpecPattern": [],"specPattern": ["packages/**/*.build.e2e.cy.js"]}}' >> cypress.env.json

--- a/.github/workflows/build-plugin-zip-tests.yml
+++ b/.github/workflows/build-plugin-zip-tests.yml
@@ -89,5 +89,9 @@ jobs:
                   cd ./build/blockera
                   npx cypress install
                   npm run env:start
+                  # Get and display WordPress version
+                  echo "Checking WordPress version..."
+                  WP_VERSION=$(wp-env run cli wp core version)
+                  echo "WordPress version: $WP_VERSION"
                   npm run test:e2e
                   npm run env:stop

--- a/.github/workflows/check-pr-config-files.yml
+++ b/.github/workflows/check-pr-config-files.yml
@@ -15,10 +15,11 @@ jobs:
 
             - name: Check for PR config files
               run: |
-                  if find . -name ".pr-*" ! -name "*.env-example*" | grep -q .; then
+                  # Find all PR config files except .pr-wp-env.json and .pr-*.env-example files
+                  if find . -name ".pr-*" ! -name ".pr-wp-env.json" ! -name "*.env-example*" | grep -q .; then
                     echo "❌ PR config files found. Please remove all PR-related config files and wait to all tests pass before merging to master."
                     echo "Found files:"
-                    find . -name ".pr-*" ! -name "*.env-example*"
+                    find . -name ".pr-*" ! -name ".pr-wp-env.json" ! -name "*.env-example*"
                     exit 1
                   else
                     echo "✅ No PR config files found. You can proceed with merging."

--- a/.github/workflows/check-pr-config-files.yml
+++ b/.github/workflows/check-pr-config-files.yml
@@ -15,11 +15,11 @@ jobs:
 
             - name: Check for PR config files
               run: |
-                  # Find all PR config files except .pr-wp-env.json and .pr-*.env-example files
-                  if find . -name ".pr-*" ! -name ".pr-wp-env.json" ! -name "*.env-example*" | grep -q .; then
+                  # Find all PR config files except  .pr-*.env-example files
+                  if find . -name ".pr-*" ! -name "*.env-example*" | grep -q .; then
                     echo "❌ PR config files found. Please remove all PR-related config files and wait to all tests pass before merging to master."
                     echo "Found files:"
-                    find . -name ".pr-*" ! -name ".pr-wp-env.json" ! -name "*.env-example*"
+                    find . -name ".pr-*" ! -name "*.env-example*"
                     exit 1
                   else
                     echo "✅ No PR config files found. You can proceed with merging."

--- a/.github/workflows/cypress-e2e-tests.yml
+++ b/.github/workflows/cypress-e2e-tests.yml
@@ -134,6 +134,9 @@ jobs:
                   echo DB=wp_tests >> .env
                   cat .env
 
+            - name: Stop WordPress Environment if running
+              run: npm run env:stop || true
+
             - name: Start WordPress Environment
               run: npm run env:start
 
@@ -142,6 +145,17 @@ jobs:
                   echo "Checking WordPress version..."
                   WP_VERSION=$(npx wp-env run cli wp core version)
                   echo "WordPress version: $WP_VERSION"
+                  if [ "${{ env.wp_env_file }}" == "true" ]; then
+                    EXPECTED_VERSION=$(jq -r '.core' .pr-wp-env.json | sed -n 's/.*wordpress-\(.*\)\.zip/\1/p')
+                    if [ "$WP_VERSION" != "$EXPECTED_VERSION" ]; then
+                      echo "Warning: WordPress version mismatch. Expected: $EXPECTED_VERSION, Got: $WP_VERSION"
+                      echo "Attempting to restart environment..."
+                      npm run env:stop
+                      npm run env:start
+                      WP_VERSION=$(npx wp-env run cli wp core version)
+                      echo "WordPress version after restart: $WP_VERSION"
+                    fi
+                  fi
 
             - name: Build wp-env app
               run: npm run build
@@ -180,6 +194,3 @@ jobs:
                   fi
 
                   npm run test:e2e -- --spec "$spec_pattern"
-
-            - name: Stop WordPress Environment
-              run: npm run env:stop

--- a/.github/workflows/cypress-e2e-tests.yml
+++ b/.github/workflows/cypress-e2e-tests.yml
@@ -140,7 +140,7 @@ jobs:
             - name: Check WordPress Version
               run: |
                   echo "Checking WordPress version..."
-                  WP_VERSION=$(wp-env run cli wp core version)
+                  WP_VERSION=$(npx wp-env run cli wp core version)
                   echo "WordPress version: $WP_VERSION"
 
             - name: Build wp-env app

--- a/.github/workflows/cypress-e2e-tests.yml
+++ b/.github/workflows/cypress-e2e-tests.yml
@@ -134,8 +134,10 @@ jobs:
                   echo DB=wp_tests >> .env
                   cat .env
 
-            - name: Stop WordPress Environment if running
-              run: npm run env:stop || true
+            - name: Stop and Destroy WordPress Environment if running
+              run: |
+                  npm run env:stop || true
+                  npx wp-env destroy || true
 
             - name: Start WordPress Environment
               run: npm run env:start
@@ -149,11 +151,12 @@ jobs:
                     EXPECTED_VERSION=$(jq -r '.core' .pr-wp-env.json | sed -n 's/.*wordpress-\(.*\)\.zip/\1/p')
                     if [ "$WP_VERSION" != "$EXPECTED_VERSION" ]; then
                       echo "Warning: WordPress version mismatch. Expected: $EXPECTED_VERSION, Got: $WP_VERSION"
-                      echo "Attempting to restart environment..."
+                      echo "Attempting to destroy and recreate environment..."
                       npm run env:stop
+                      npx wp-env destroy
                       npm run env:start
                       WP_VERSION=$(npx wp-env run cli wp core version)
-                      echo "WordPress version after restart: $WP_VERSION"
+                      echo "WordPress version after recreation: $WP_VERSION"
                     fi
                   fi
 

--- a/.github/workflows/cypress-e2e-tests.yml
+++ b/.github/workflows/cypress-e2e-tests.yml
@@ -117,7 +117,9 @@ jobs:
                       ;;
                   esac
 
-                  if [ "${{ env.wp_env_file }}" == "true" ]; then
+                  # First verify the file exists again
+                  if [ -f ".pr-wp-env.json" ] && [ "${{ env.wp_env_file }}" = "true" ]; then
+                    echo "Found .pr-wp-env.json in $(pwd)"
                     # Extract core version from .pr-wp-env.json
                     echo "Reading .pr-wp-env.json..."
                     cat .pr-wp-env.json
@@ -131,6 +133,7 @@ jobs:
                     # Ensure BLOCKERA_TELEMETRY_OPT_IN_OFF is set unless explicitly disabled
                     jq '.config.BLOCKERA_TELEMETRY_OPT_IN_OFF = true' .wp-env.json > tmp.json && mv tmp.json .wp-env.json
                   else
+                    echo "No .pr-wp-env.json found in $(pwd) or wp_env_file is not true"
                     # Add telemetry config to base configuration
                     echo "$BASE_CONFIG" | jq '.config.BLOCKERA_TELEMETRY_OPT_IN_OFF = true' > .wp-env.json
                   fi

--- a/.github/workflows/cypress-e2e-tests.yml
+++ b/.github/workflows/cypress-e2e-tests.yml
@@ -33,6 +33,16 @@ jobs:
                     echo "env_file=false" >> $GITHUB_ENV
                   fi
 
+            - name: Check if .pr-wp-env.json exists
+              id: check_wp_env_file
+              run: |
+                  if [ -f ".pr-wp-env.json" ]; then
+                    echo "Found .pr-wp-env.json"
+                    echo "wp_env_file=true" >> $GITHUB_ENV
+                  else
+                    echo "wp_env_file=false" >> $GITHUB_ENV
+                  fi
+
             - name: List test categories
               id: set_categories
               run: |
@@ -88,23 +98,36 @@ jobs:
 
             - name: Create required environment files
               run: |
+                  # Set up base configuration based on category
                   case "${{ matrix.category }}" in
                     "woocommerce")
-                      echo '{"plugins": [".", "https://downloads.wordpress.org/plugin/woocommerce.latest-stable.zip"], "config": {"BLOCKERA_TELEMETRY_OPT_IN_OFF": true}}' >> .wp-env.json
+                      BASE_CONFIG='{"plugins": [".", "https://downloads.wordpress.org/plugin/woocommerce.latest-stable.zip"]}'
                       ;;  
                     "blocksy")
-                      echo '{"plugins": [".", "https://downloads.wordpress.org/plugin/blocksy-companion.latest-stable.zip"], "themes": ["https://downloads.wordpress.org/theme/blocksy.latest-stable.zip"], "config": {"BLOCKERA_TELEMETRY_OPT_IN_OFF": true}, "lifecycleScripts": {"afterStart": "wp-env run cli wp theme activate blocksy"}}' >> .wp-env.json
+                      BASE_CONFIG='{"plugins": [".", "https://downloads.wordpress.org/plugin/blocksy-companion.latest-stable.zip"], "themes": ["https://downloads.wordpress.org/theme/blocksy.latest-stable.zip"], "lifecycleScripts": {"afterStart": "wp-env run cli wp theme activate blocksy"}}'
                       ;;
                     "telemetry")
-                      echo '{"plugins": ["."], "config": {"BLOCKERA_TELEMETRY_NOT_STORE_DATA": true}}' >> .wp-env.json
+                      BASE_CONFIG='{"plugins": ["."], "config": {"BLOCKERA_TELEMETRY_NOT_STORE_DATA": true}}'
                       ;;
                     "plugins")
-                      echo '{"plugins": [".", "https://downloads.wordpress.org/plugin/icon-block.latest-stable.zip"], "config": {"BLOCKERA_TELEMETRY_OPT_IN_OFF": true}}' >> .wp-env.json
+                      BASE_CONFIG='{"plugins": [".", "https://downloads.wordpress.org/plugin/icon-block.latest-stable.zip"]}'
                       ;;
                     *)
-                      echo '{"plugins": [".", "https://downloads.wordpress.org/plugin/svg-support.latest-stable.zip"], "config": {"BLOCKERA_TELEMETRY_OPT_IN_OFF": true}}' >> .wp-env.json
+                      BASE_CONFIG='{"plugins": [".", "https://downloads.wordpress.org/plugin/svg-support.latest-stable.zip"]}'
                       ;;
                   esac
+
+                  if [ "${{ env.wp_env_file }}" == "true" ]; then
+                    # Merge PR wp-env config with base config
+                    echo "$BASE_CONFIG" > base-config.json
+                    jq -s '.[0] * .[1]' base-config.json .pr-wp-env.json > .wp-env.json
+                    # Ensure BLOCKERA_TELEMETRY_OPT_IN_OFF is set unless explicitly disabled
+                    jq '.config.BLOCKERA_TELEMETRY_OPT_IN_OFF = true' .wp-env.json > tmp.json && mv tmp.json .wp-env.json
+                  else
+                    # Add telemetry config to base configuration
+                    echo "$BASE_CONFIG" | jq '.config.BLOCKERA_TELEMETRY_OPT_IN_OFF = true' > .wp-env.json
+                  fi
+
                   cat .wp-env.json
                   touch .env
                   echo APP_MODE=production >> .env

--- a/.github/workflows/cypress-e2e-tests.yml
+++ b/.github/workflows/cypress-e2e-tests.yml
@@ -118,6 +118,13 @@ jobs:
                   esac
 
                   if [ "${{ env.wp_env_file }}" == "true" ]; then
+                    # Extract core version from .pr-wp-env.json
+                    echo "Reading .pr-wp-env.json..."
+                    cat .pr-wp-env.json
+                    CORE_VERSION=$(jq -r '.core' .pr-wp-env.json)
+                    echo "Extracted core version: $CORE_VERSION"
+                    echo "WP_ENV_CORE=$CORE_VERSION" >> $GITHUB_ENV
+                    echo "Environment variable set to: $CORE_VERSION"
                     # Merge PR wp-env config with base config
                     echo "$BASE_CONFIG" > base-config.json
                     jq -s '.[0] * .[1]' base-config.json .pr-wp-env.json > .wp-env.json
@@ -128,6 +135,7 @@ jobs:
                     echo "$BASE_CONFIG" | jq '.config.BLOCKERA_TELEMETRY_OPT_IN_OFF = true' > .wp-env.json
                   fi
 
+                  echo "Final .wp-env.json contents:"
                   cat .wp-env.json
                   touch .env
                   echo APP_MODE=production >> .env
@@ -145,10 +153,12 @@ jobs:
             - name: Check WordPress Version
               run: |
                   echo "Checking WordPress version..."
+                  echo "Current WP_ENV_CORE environment variable: $WP_ENV_CORE"
                   WP_VERSION=$(npx wp-env run cli wp core version)
                   echo "WordPress version: $WP_VERSION"
                   if [ "${{ env.wp_env_file }}" == "true" ]; then
                     EXPECTED_VERSION=$(jq -r '.core' .pr-wp-env.json | sed -n 's/.*wordpress-\(.*\)\.zip/\1/p')
+                    echo "Expected version from .pr-wp-env.json: $EXPECTED_VERSION"
                     if [ "$WP_VERSION" != "$EXPECTED_VERSION" ]; then
                       echo "Warning: WordPress version mismatch. Expected: $EXPECTED_VERSION, Got: $WP_VERSION"
                       echo "Attempting to destroy and recreate environment..."

--- a/.github/workflows/cypress-e2e-tests.yml
+++ b/.github/workflows/cypress-e2e-tests.yml
@@ -137,6 +137,12 @@ jobs:
             - name: Start WordPress Environment
               run: npm run env:start
 
+            - name: Check WordPress Version
+              run: |
+                  echo "Checking WordPress version..."
+                  WP_VERSION=$(wp-env run cli wp core version)
+                  echo "WordPress version: $WP_VERSION"
+
             - name: Build wp-env app
               run: npm run build
 

--- a/.github/workflows/cypress-visual-tests.yml
+++ b/.github/workflows/cypress-visual-tests.yml
@@ -159,7 +159,7 @@ jobs:
             - name: Check WordPress Version
               run: |
                   echo "Checking WordPress version..."
-                  WP_VERSION=$(wp-env run cli wp core version)
+                  WP_VERSION=$(npx wp-env run cli wp core version)
                   echo "WordPress version: $WP_VERSION"
 
             - name: Build wp-env app

--- a/.github/workflows/cypress-visual-tests.yml
+++ b/.github/workflows/cypress-visual-tests.yml
@@ -153,8 +153,10 @@ jobs:
                   echo DB=wp_tests >> .env
                   cat .env
 
-            - name: Stop WordPress Environment if running
-              run: npm run env:stop || true
+            - name: Stop and Destroy WordPress Environment if running
+              run: |
+                  npm run env:stop || true
+                  npx wp-env destroy || true
 
             - name: Start WordPress Environment
               run: npm run env:start
@@ -168,11 +170,12 @@ jobs:
                     EXPECTED_VERSION=$(jq -r '.core' .pr-wp-env.json | sed -n 's/.*wordpress-\(.*\)\.zip/\1/p')
                     if [ "$WP_VERSION" != "$EXPECTED_VERSION" ]; then
                       echo "Warning: WordPress version mismatch. Expected: $EXPECTED_VERSION, Got: $WP_VERSION"
-                      echo "Attempting to restart environment..."
+                      echo "Attempting to destroy and recreate environment..."
                       npm run env:stop
+                      npx wp-env destroy
                       npm run env:start
                       WP_VERSION=$(npx wp-env run cli wp core version)
-                      echo "WordPress version after restart: $WP_VERSION"
+                      echo "WordPress version after recreation: $WP_VERSION"
                     fi
                   fi
 

--- a/.github/workflows/cypress-visual-tests.yml
+++ b/.github/workflows/cypress-visual-tests.yml
@@ -153,6 +153,9 @@ jobs:
                   echo DB=wp_tests >> .env
                   cat .env
 
+            - name: Stop WordPress Environment if running
+              run: npm run env:stop || true
+
             - name: Start WordPress Environment
               run: npm run env:start
 
@@ -161,6 +164,17 @@ jobs:
                   echo "Checking WordPress version..."
                   WP_VERSION=$(npx wp-env run cli wp core version)
                   echo "WordPress version: $WP_VERSION"
+                  if [ "${{ env.wp_env_file }}" == "true" ]; then
+                    EXPECTED_VERSION=$(jq -r '.core' .pr-wp-env.json | sed -n 's/.*wordpress-\(.*\)\.zip/\1/p')
+                    if [ "$WP_VERSION" != "$EXPECTED_VERSION" ]; then
+                      echo "Warning: WordPress version mismatch. Expected: $EXPECTED_VERSION, Got: $WP_VERSION"
+                      echo "Attempting to restart environment..."
+                      npm run env:stop
+                      npm run env:start
+                      WP_VERSION=$(npx wp-env run cli wp core version)
+                      echo "WordPress version after restart: $WP_VERSION"
+                    fi
+                  fi
 
             - name: Build wp-env app
               run: npm run build

--- a/.github/workflows/cypress-visual-tests.yml
+++ b/.github/workflows/cypress-visual-tests.yml
@@ -33,6 +33,16 @@ jobs:
                     echo "env_file=false" >> $GITHUB_ENV
                   fi
 
+            - name: Check if .pr-wp-env.json exists
+              id: check_wp_env_file
+              run: |
+                  if [ -f ".pr-wp-env.json" ]; then
+                    echo "Found .pr-wp-env.json"
+                    echo "wp_env_file=true" >> $GITHUB_ENV
+                  else
+                    echo "wp_env_file=false" >> $GITHUB_ENV
+                  fi
+
             - name: List test categories
               id: set_categories
               run: |
@@ -107,23 +117,36 @@ jobs:
 
             - name: Create required environment files
               run: |
+                  # Set up base configuration based on category
                   case "${{ matrix.category }}" in
                   "woocommerce")
-                   	echo '{"plugins": [".", "https://downloads.wordpress.org/plugin/woocommerce.latest-stable.zip"], "config": {"BLOCKERA_TELEMETRY_OPT_IN_OFF": true}}' >> .wp-env.json
-                  	;;  
+                    BASE_CONFIG='{"plugins": [".", "https://downloads.wordpress.org/plugin/woocommerce.latest-stable.zip"]}'
+                    ;;  
                   "blocksy")
-                  	echo '{"plugins": ["."], "themes": ["https://downloads.wordpress.org/theme/blocksy.latest-stable.zip"], "config": {"BLOCKERA_TELEMETRY_OPT_IN_OFF": true}, "lifecycleScripts": {"afterStart": "wp-env run cli wp theme activate blocksy"}}' >> .wp-env.json
-                      ;;
+                    BASE_CONFIG='{"plugins": ["."], "themes": ["https://downloads.wordpress.org/theme/blocksy.latest-stable.zip"], "lifecycleScripts": {"afterStart": "wp-env run cli wp theme activate blocksy"}}'
+                    ;;
                   "telemetry")
-                      echo '{"plugins": ["."], "config": {"BLOCKERA_TELEMETRY_NOT_STORE_DATA": true}}' >> .wp-env.json
-                      ;;
+                    BASE_CONFIG='{"plugins": ["."], "config": {"BLOCKERA_TELEMETRY_NOT_STORE_DATA": true}}'
+                    ;;
                   "plugins")
-                      echo '{"plugins": [".", "https://downloads.wordpress.org/plugin/icon-block.latest-stable.zip"], "config": {"BLOCKERA_TELEMETRY_OPT_IN_OFF": true}}' >> .wp-env.json
-                      ;;
+                    BASE_CONFIG='{"plugins": [".", "https://downloads.wordpress.org/plugin/icon-block.latest-stable.zip"]}'
+                    ;;
                   *)
-                   	echo '{"plugins": [".", "https://downloads.wordpress.org/plugin/svg-support.latest-stable.zip"], "config": {"BLOCKERA_TELEMETRY_OPT_IN_OFF": true}}' >> .wp-env.json
-                   	;;
+                    BASE_CONFIG='{"plugins": [".", "https://downloads.wordpress.org/plugin/svg-support.latest-stable.zip"]}'
+                    ;;
                   esac
+
+                  if [ "${{ env.wp_env_file }}" == "true" ]; then
+                    # Merge PR wp-env config with base config
+                    echo "$BASE_CONFIG" > base-config.json
+                    jq -s '.[0] * .[1]' base-config.json .pr-wp-env.json > .wp-env.json
+                    # Ensure BLOCKERA_TELEMETRY_OPT_IN_OFF is set unless explicitly disabled
+                    jq '.config.BLOCKERA_TELEMETRY_OPT_IN_OFF = true' .wp-env.json > tmp.json && mv tmp.json .wp-env.json
+                  else
+                    # Add telemetry config to base configuration
+                    echo "$BASE_CONFIG" | jq '.config.BLOCKERA_TELEMETRY_OPT_IN_OFF = true' > .wp-env.json
+                  fi
+
                   cat .wp-env.json
                   touch .env
                   echo APP_MODE=production >> .env

--- a/.github/workflows/cypress-visual-tests.yml
+++ b/.github/workflows/cypress-visual-tests.yml
@@ -137,6 +137,9 @@ jobs:
                   esac
 
                   if [ "${{ env.wp_env_file }}" == "true" ]; then
+                    # Extract core version from .pr-wp-env.json
+                    CORE_VERSION=$(jq -r '.core' .pr-wp-env.json)
+                    echo "WP_ENV_CORE=$CORE_VERSION" >> $GITHUB_ENV
                     # Merge PR wp-env config with base config
                     echo "$BASE_CONFIG" > base-config.json
                     jq -s '.[0] * .[1]' base-config.json .pr-wp-env.json > .wp-env.json

--- a/.github/workflows/cypress-visual-tests.yml
+++ b/.github/workflows/cypress-visual-tests.yml
@@ -156,6 +156,12 @@ jobs:
             - name: Start WordPress Environment
               run: npm run env:start
 
+            - name: Check WordPress Version
+              run: |
+                  echo "Checking WordPress version..."
+                  WP_VERSION=$(wp-env run cli wp core version)
+                  echo "WordPress version: $WP_VERSION"
+
             - name: Build wp-env app
               run: npm run build
 

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -111,6 +111,9 @@ jobs:
             - name: Create requires environment files
               run: |
                   if [ "${{ env.wp_env_file }}" == "true" ]; then
+                    # Extract core version from .pr-wp-env.json
+                    CORE_VERSION=$(jq -r '.core' .pr-wp-env.json)
+                    echo "WP_ENV_CORE=$CORE_VERSION" >> $GITHUB_ENV
                     # Use PR wp-env config but ensure PHP version is set correctly
                     jq --arg php "${{ matrix.php }}" '.phpVersion = $php' .pr-wp-env.json > .wp-env.json
                   else
@@ -121,12 +124,6 @@ jobs:
                   echo APP_MODE=production >> .env
                   echo DB=wp_tests >> .env
                   cat .env
-
-            - name: Update WordPress core version if specified
-              if: env.wp_core_version != ''
-              run: |
-                  echo "Using WordPress core version from .pr-wp-env.json: ${{ env.wp_core_version }}"
-                  echo "WP_ENV_CORE=${{ env.wp_core_version }}" >> $GITHUB_ENV
 
             - name: Stop and Destroy WordPress Environment if running
               run: |

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -128,8 +128,10 @@ jobs:
                   echo "Using WordPress core version from .pr-wp-env.json: ${{ env.wp_core_version }}"
                   echo "WP_ENV_CORE=${{ env.wp_core_version }}" >> $GITHUB_ENV
 
-            - name: Stop WordPress Environment if running
-              run: npm run env:stop || true
+            - name: Stop and Destroy WordPress Environment if running
+              run: |
+                  npm run env:stop || true
+                  npx wp-env destroy || true
 
             - name: Start WordPress Environment
               run: npm run env:start
@@ -143,11 +145,12 @@ jobs:
                     EXPECTED_VERSION=$(jq -r '.core' .pr-wp-env.json | sed -n 's/.*wordpress-\(.*\)\.zip/\1/p')
                     if [ "$WP_VERSION" != "$EXPECTED_VERSION" ]; then
                       echo "Warning: WordPress version mismatch. Expected: $EXPECTED_VERSION, Got: $WP_VERSION"
-                      echo "Attempting to restart environment..."
+                      echo "Attempting to destroy and recreate environment..."
                       npm run env:stop
+                      npx wp-env destroy
                       npm run env:start
                       WP_VERSION=$(npx wp-env run cli wp core version)
-                      echo "WordPress version after restart: $WP_VERSION"
+                      echo "WordPress version after recreation: $WP_VERSION"
                     fi
                   fi
 

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -131,6 +131,12 @@ jobs:
             - name: Start WordPress Environment
               run: npm run env:start
 
+            - name: Check WordPress Version
+              run: |
+                  echo "Checking WordPress version..."
+                  WP_VERSION=$(wp-env run cli wp core version)
+                  echo "WordPress version: $WP_VERSION"
+
             - name: Running single site unit tests
               if: ${{ ! matrix.multisite }}
               run: |

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -94,15 +94,39 @@ jobs:
                   git --version
                   locale -a
 
+            - name: Check if .pr-wp-env.json exists
+              id: check_wp_env_file
+              run: |
+                  if [ -f ".pr-wp-env.json" ]; then
+                    echo "Found .pr-wp-env.json"
+                    echo "wp_env_file=true" >> $GITHUB_ENV
+                    # Extract core version if specified
+                    if core_version=$(jq -r '.core // empty' .pr-wp-env.json); then
+                      echo "wp_core_version=${core_version}" >> $GITHUB_ENV
+                    fi
+                  else
+                    echo "wp_env_file=false" >> $GITHUB_ENV
+                  fi
+
             - name: Create requires environment files
               run: |
-                  touch .wp-env.json
-                  echo '{"plugins": ["."],"phpVersion": "${{ matrix.php }}"}' >> .wp-env.json
+                  if [ "${{ env.wp_env_file }}" == "true" ]; then
+                    # Use PR wp-env config but ensure PHP version is set correctly
+                    jq --arg php "${{ matrix.php }}" '.phpVersion = $php' .pr-wp-env.json > .wp-env.json
+                  else
+                    echo '{"plugins": ["."],"phpVersion": "${{ matrix.php }}"}' >> .wp-env.json
+                  fi
                   cat .wp-env.json
                   touch .env
                   echo APP_MODE=production >> .env
                   echo DB=wp_tests >> .env
                   cat .env
+
+            - name: Update WordPress core version if specified
+              if: env.wp_core_version != ''
+              run: |
+                  echo "Using WordPress core version from .pr-wp-env.json: ${{ env.wp_core_version }}"
+                  echo "WP_ENV_CORE=${{ env.wp_core_version }}" >> $GITHUB_ENV
 
             - name: Start WordPress Environment
               run: npm run env:start

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -128,6 +128,9 @@ jobs:
                   echo "Using WordPress core version from .pr-wp-env.json: ${{ env.wp_core_version }}"
                   echo "WP_ENV_CORE=${{ env.wp_core_version }}" >> $GITHUB_ENV
 
+            - name: Stop WordPress Environment if running
+              run: npm run env:stop || true
+
             - name: Start WordPress Environment
               run: npm run env:start
 
@@ -136,6 +139,17 @@ jobs:
                   echo "Checking WordPress version..."
                   WP_VERSION=$(npx wp-env run cli wp core version)
                   echo "WordPress version: $WP_VERSION"
+                  if [ "${{ env.wp_env_file }}" == "true" ]; then
+                    EXPECTED_VERSION=$(jq -r '.core' .pr-wp-env.json | sed -n 's/.*wordpress-\(.*\)\.zip/\1/p')
+                    if [ "$WP_VERSION" != "$EXPECTED_VERSION" ]; then
+                      echo "Warning: WordPress version mismatch. Expected: $EXPECTED_VERSION, Got: $WP_VERSION"
+                      echo "Attempting to restart environment..."
+                      npm run env:stop
+                      npm run env:start
+                      WP_VERSION=$(npx wp-env run cli wp core version)
+                      echo "WordPress version after restart: $WP_VERSION"
+                    fi
+                  fi
 
             - name: Running single site unit tests
               if: ${{ ! matrix.multisite }}

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -134,7 +134,7 @@ jobs:
             - name: Check WordPress Version
               run: |
                   echo "Checking WordPress version..."
-                  WP_VERSION=$(wp-env run cli wp core version)
+                  WP_VERSION=$(npx wp-env run cli wp core version)
                   echo "WordPress version: $WP_VERSION"
 
             - name: Running single site unit tests

--- a/.github/workflows/remove-pr-config-files.yml
+++ b/.github/workflows/remove-pr-config-files.yml
@@ -16,7 +16,9 @@ jobs:
               uses: actions/checkout@v4
 
             - name: Remove Pull Request env files
-              run: rm -rf .pr-* ! -name "*.example"
+              run: |
+                  # Find and remove all .pr-* files except .example files
+                  find . -name ".pr-*" ! -name "*.example" -exec rm -f {} +
 
             # Step 3: Configure Git (required for committing changes)
             - name: Set up Git

--- a/.pr-wp-env.json
+++ b/.pr-wp-env.json
@@ -1,0 +1,7 @@
+{
+	"core": "https://wordpress.org/wordpress-6.8-beta1.zip",
+	"plugins": ["."],
+	"config": {
+		"WP_DEBUG": true
+	}
+}


### PR DESCRIPTION
We should have infrastructure for running CI tests for specific WP versions and configs like RC versions. the `.pr-wp-env.json` makes it available.