### PR TITLE
Feat: Inline Block Renaming from the Block Card

### DIFF
--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -1,5 +1,20 @@
 ## Unreleased
 
+### New Features
+- Inline block renaming by clicking on block card [[🔗 Feature request](https://community.blockera.ai/feature-request-1rsjg2ck/post/block-renaming-quick-block-renaming-from-the-block-card-j7XmvUiOTj36VFn)]
+
+
+### Improvements
+- Improve block card design.
+- Improve overall codes.
+
+
+### Automated Tests
+- Added E2E tests to check inline block renaming.
+- Added E2E test to check inline block renaming for blocks with variations.
+
+
+
 ## 1.2.4 (2025-04-16)
 
 ### Improvements

--- a/packages/editor/js/extensions/components/block-fill-partials.js
+++ b/packages/editor/js/extensions/components/block-fill-partials.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import memoize from 'fast-memoize';
-import { select } from '@wordpress/data';
+import { select, useDispatch } from '@wordpress/data';
 import type { ComponentType, Element } from 'react';
 import { Fill } from '@wordpress/components';
 import { useEffect, memo } from '@wordpress/element';
@@ -34,6 +34,8 @@ export const BlockFillPartials: ComponentType<any> = memo(
 		blockeraInnerBlocks,
 		updateBlockEditorSettings,
 	}): Element<any> => {
+		const { updateBlockAttributes } = useDispatch('core/block-editor');
+
 		// prevent memory leak, componentDidMount.
 		useEffect(() => {
 			const others = select('blockera/controls').getControls();
@@ -57,6 +59,17 @@ export const BlockFillPartials: ComponentType<any> = memo(
 			);
 		}, [isActive]);
 
+		const handleOnChangeAttributes = (
+			attribute: string,
+			value: any
+		): void => {
+			if (attribute === 'name') {
+				updateBlockAttributes(clientId, { metadata: { name: value } });
+			} else {
+				updateBlockAttributes(clientId, { [attribute]: value });
+			}
+		};
+
 		return (
 			<>
 				<Fill name={`blockera-block-card-content-${clientId}`}>
@@ -66,7 +79,7 @@ export const BlockFillPartials: ComponentType<any> = memo(
 						blockName={blockProps.name}
 						innerBlocks={blockeraInnerBlocks}
 						currentInnerBlock={currentInnerBlock}
-						handleOnClick={updateBlockEditorSettings}
+						handleOnChangeAttributes={handleOnChangeAttributes}
 					/>
 
 					{isInnerBlock(currentBlock) && (

--- a/packages/editor/js/extensions/components/block-fill-partials.js
+++ b/packages/editor/js/extensions/components/block-fill-partials.js
@@ -64,6 +64,10 @@ export const BlockFillPartials: ComponentType<any> = memo(
 			value: any
 		): void => {
 			if (attribute === 'name') {
+				if (value === '' || value === null) {
+					value = undefined;
+				}
+
 				updateBlockAttributes(clientId, { metadata: { name: value } });
 			} else {
 				updateBlockAttributes(clientId, { [attribute]: value });

--- a/packages/editor/js/extensions/components/test/block-partials.e2e.cy.js
+++ b/packages/editor/js/extensions/components/test/block-partials.e2e.cy.js
@@ -18,7 +18,14 @@ describe('Block Partials Testing ...', () => {
 			'none'
 		);
 
-		cy.getByDataTest('blockera-block-card').contains('Paragraph');
+		cy.getByDataTest('blockera-block-card').within(() => {
+			cy.get('.blockera-extension-block-card__title__input span').should(
+				'have.attr',
+				'placeholder',
+				'Paragraph'
+			);
+		});
+
 		cy.getByDataTest('blockera-block-card').should(
 			'have.css',
 			'display',

--- a/packages/editor/js/extensions/libs/block-card/components/block-card.scss
+++ b/packages/editor/js/extensions/libs/block-card/components/block-card.scss
@@ -64,7 +64,58 @@
 			align-items: center;
 			min-height: 24px;
 			gap: 5px;
+			padding-right: 45px;
 			flex-wrap: wrap;
+
+			.blockera-extension-block-card__title__input {
+
+				span {
+					max-width: 160px;
+					white-space: nowrap;
+					overflow: hidden;
+					cursor: text;
+					border: none;
+					outline: none;
+					box-shadow: none;
+					background-color: transparent;
+					opacity: 1;
+					font-weight: 500;
+					color: #1e1e1e;
+					padding: 2px 3px;
+					border-radius: 2px;
+					min-width: 1px;
+					display: inline-block;
+				}
+
+				span:not(:focus) {
+					text-overflow: ellipsis;
+				}
+
+				span:hover,
+				span:focus,
+				&.is-edited span {
+					background: #f3f8fb !important;
+					box-shadow: 0 0 0 1px #c7e0ee !important;
+					color: #147eb8 !important;
+					--blockera-controls-primary-color: #147eb8;
+				}
+
+				span:focus:focus {
+					box-shadow: 0 0 0 2px var(--blockera-controls-primary-color) !important;
+				}
+
+				span::placeholder {
+					opacity: 1;
+					font-weight: 500;
+					color: #1e1e1e;
+				}
+
+				span:empty::before {
+					content: attr(placeholder);
+					font-weight: 500;
+					color: #1e1e1e;
+				}
+			}
 
 			.blockera-extension-block-card__title__separator {
 				color: #1e1e1e;
@@ -121,6 +172,7 @@
 			-webkit-box-orient: vertical;
 			-webkit-line-clamp: 2;
 			overflow: hidden;
+			cursor: default;
 		}
 
 		.block-editor-block-variation-transforms {
@@ -173,6 +225,16 @@
 		.blockera-component-block-icon {
 			color: var(--blockera-controls-primary-color);
 		}
+	}
+}
+
+.blockera-extension.blockera-extension-block-card.master-block-card {
+
+	// remove the 3 px margin left space because of the input padding
+
+	.blockera-extension-block-card__title__input {
+		margin-left: -3px;
+		margin-right: -3px;
 	}
 }
 

--- a/packages/editor/js/extensions/libs/block-card/components/editable-block-name.js
+++ b/packages/editor/js/extensions/libs/block-card/components/editable-block-name.js
@@ -1,0 +1,77 @@
+// @flow
+
+/**
+ * External dependencies
+ */
+import type { MixedElement } from 'react';
+import { useState, useRef, useEffect } from '@wordpress/element';
+
+export function EditableBlockName({
+	placeholder,
+	content,
+	onChange,
+}: {
+	placeholder: string,
+	content: string,
+	onChange: (content: string) => void,
+}): MixedElement {
+	const [text, setText] = useState(content);
+	const ref = useRef(null);
+
+	useEffect(() => {
+		const currentText = (ref && ref?.current?.textContent) || '';
+
+		if (content !== currentText) {
+			setText(content);
+		}
+	}, [content]);
+
+	const emitChange = (event: SyntheticInputEvent<HTMLSpanElement>) => {
+		const newContent = (event.currentTarget.textContent || '').trim();
+
+		if (content !== newContent) {
+			onChange(newContent);
+		}
+
+		if (newContent === '') {
+			ref.current.textContent = '';
+		}
+	};
+
+	const handleBlur = (event: SyntheticFocusEvent<HTMLSpanElement>) => {
+		// Move scroll position to the beginning of the element
+		event.currentTarget.scrollLeft = 0;
+
+		// Deselect any selected text
+		event.currentTarget.ownerDocument.defaultView
+			?.getSelection()
+			?.removeAllRanges();
+	};
+
+	return (
+		<span
+			ref={ref}
+			placeholder={placeholder}
+			contentEditable="true"
+			suppressContentEditableWarning={true}
+			onInput={emitChange}
+			onBlur={handleBlur}
+			onKeyDown={(e) => {
+				// Prevent newlines
+				if (e.key === 'Enter') {
+					e.currentTarget.blur();
+					return;
+				}
+
+				// Handle Escape key to clear name
+				if (e.key === 'Escape') {
+					e.currentTarget.textContent = '';
+					emitChange(e);
+					e.currentTarget.blur();
+				}
+			}}
+		>
+			{text}
+		</span>
+	);
+}

--- a/packages/editor/js/extensions/libs/block-card/components/editable-block-name.js
+++ b/packages/editor/js/extensions/libs/block-card/components/editable-block-name.js
@@ -54,6 +54,16 @@ export function EditableBlockName({
 		setIsFocused(true);
 	};
 
+	const handlePaste = (event: SyntheticClipboardEvent<HTMLSpanElement>) => {
+		event.preventDefault();
+		const pastedText = event.clipboardData.getData('text/plain');
+		// Remove HTML tags and newlines
+		const cleanText = pastedText
+			.replace(/<[^>]*>/g, '')
+			.replace(/[\r\n\t]+/g, ' ');
+		document.execCommand('insertText', false, cleanText);
+	};
+
 	return (
 		<span
 			ref={ref}
@@ -64,6 +74,7 @@ export function EditableBlockName({
 			onInput={emitChange}
 			onBlur={handleBlur}
 			onFocus={handleFocus}
+			onPaste={handlePaste}
 			onKeyDown={(e) => {
 				// Prevent newlines
 				if (e.key === 'Enter') {

--- a/packages/editor/js/extensions/libs/block-card/components/editable-block-name.js
+++ b/packages/editor/js/extensions/libs/block-card/components/editable-block-name.js
@@ -16,6 +16,7 @@ export function EditableBlockName({
 	onChange: (content: string) => void,
 }): MixedElement {
 	const [text, setText] = useState(content);
+	const [isFocused, setIsFocused] = useState(false);
 	const ref = useRef(null);
 
 	useEffect(() => {
@@ -39,6 +40,7 @@ export function EditableBlockName({
 	};
 
 	const handleBlur = (event: SyntheticFocusEvent<HTMLSpanElement>) => {
+		setIsFocused(false);
 		// Move scroll position to the beginning of the element
 		event.currentTarget.scrollLeft = 0;
 
@@ -48,14 +50,20 @@ export function EditableBlockName({
 			?.removeAllRanges();
 	};
 
+	const handleFocus = () => {
+		setIsFocused(true);
+	};
+
 	return (
 		<span
 			ref={ref}
 			placeholder={placeholder}
 			contentEditable="true"
 			suppressContentEditableWarning={true}
+			spellCheck={isFocused}
 			onInput={emitChange}
 			onBlur={handleBlur}
+			onFocus={handleFocus}
 			onKeyDown={(e) => {
 				// Prevent newlines
 				if (e.key === 'Enter') {

--- a/packages/editor/js/extensions/libs/block-card/test/block-card.e2e.cy.js
+++ b/packages/editor/js/extensions/libs/block-card/test/block-card.e2e.cy.js
@@ -1,7 +1,12 @@
 /**
  * Blockera dependencies
  */
-import { createPost, appendBlocks } from '@blockera/dev-cypress/js/helpers';
+import {
+	createPost,
+	appendBlocks,
+	getWPDataObject,
+	getSelectedBlock,
+} from '@blockera/dev-cypress/js/helpers';
 
 describe('Block Card', () => {
 	beforeEach(() => {
@@ -18,7 +23,10 @@ describe('Block Card', () => {
 		cy.get('.blockera-block-card-wrapper').should('have.class', 'is-stuck');
 	});
 
-	it('Check showing block custom name', () => {
+	it('Inline edit block name + variation', () => {
+		//
+		// 1. Block with custom name and default name
+		//
 		appendBlocks(`<!-- wp:paragraph {"metadata":{"name":"My custom name"}} -->
 <p>Block with custom name</p>
 <!-- /wp:paragraph -->
@@ -33,19 +41,245 @@ describe('Block Card', () => {
 		//
 		cy.getBlock('core/paragraph').first().click();
 
-		cy.get('.blockera-extension-block-card__title__block').should(
+		cy.get('.blockera-extension-block-card__title__input').should(
+			'have.class',
+			'is-edited'
+		);
+
+		cy.get('.blockera-extension-block-card__title__input span').should(
 			'have.text',
 			'My custom name'
 		);
+
+		getWPDataObject().then((data) => {
+			expect('My custom name').to.be.equal(
+				getSelectedBlock(data, 'metadata')?.name
+			);
+		});
 
 		//
 		// Switch to second block and check block card title
 		//
 		cy.getBlock('core/paragraph').last().click();
 
-		cy.get('.blockera-extension-block-card__title__block').should(
-			'have.text',
-			'Paragraph'
+		cy.get('.blockera-extension-block-card__title__input').should(
+			'not.have.class',
+			'is-edited'
 		);
+
+		cy.get('.blockera-extension-block-card__title__input span')
+			.should('have.text', '')
+			.should('have.attr', 'placeholder', 'Paragraph');
+
+		getWPDataObject().then((data) => {
+			expect(undefined).to.be.equal(
+				getSelectedBlock(data, 'metadata')?.name
+			);
+		});
+
+		//
+		// 2. Rename block name
+		//
+		cy.getBlock('core/paragraph').last().click();
+
+		cy.get('.blockera-extension-block-card__title__input span').click();
+
+		cy.get('.blockera-extension-block-card__title__input span').type(
+			'New custom name'
+		);
+
+		cy.get('.blockera-extension-block-card__title__input span').blur();
+
+		cy.get('.blockera-extension-block-card__title__input').should(
+			'have.class',
+			'is-edited'
+		);
+
+		cy.get('.blockera-extension-block-card__title__input span').should(
+			'have.text',
+			'New custom name'
+		);
+
+		getWPDataObject().then((data) => {
+			expect('New custom name').to.be.equal(
+				getSelectedBlock(data, 'metadata')?.name
+			);
+		});
+
+		//
+		// 3. Rename block name with Escape key
+		//
+		cy.getBlock('core/paragraph').last().click();
+
+		cy.get('.blockera-extension-block-card__title__input span').click();
+
+		cy.get('.blockera-extension-block-card__title__input span').type(
+			'{esc}'
+		);
+
+		cy.get('.blockera-extension-block-card__title__input').should(
+			'not.have.class',
+			'is-edited'
+		);
+
+		cy.get('.blockera-extension-block-card__title__input span')
+			.should('have.text', '')
+			.should('have.attr', 'placeholder', 'Paragraph');
+
+		getWPDataObject().then((data) => {
+			expect(undefined).to.be.equal(
+				getSelectedBlock(data, 'metadata')?.name
+			);
+		});
+
+		//
+		// 4. check rename and block variation
+		//
+		appendBlocks(`<!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:paragraph {"style":{"color":{"background":"#ffd2d2"}}} -->
+<p class="has-background" style="background-color:#ffd2d2">Paragraph 1</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph {"style":{"color":{"background":"#ffe3e3"}}} -->
+<p class="has-background" style="background-color:#ffe3e3">Paragraph 2</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group -->`);
+
+		// Select target block
+		cy.getBlock('core/paragraph').first().click();
+
+		// Switch to parent block
+		cy.getByAriaLabel('Select parent block: Group').click();
+
+		//
+		// 4.1. check block card title for default variation
+		//
+		cy.get('.blockera-extension-block-card__title__input').should(
+			'not.have.class',
+			'is-edited'
+		);
+
+		cy.get('.blockera-extension-block-card__title__input span')
+			.should('have.text', '')
+			.should('have.attr', 'placeholder', 'Group');
+
+		getWPDataObject().then((data) => {
+			expect(undefined).to.be.equal(
+				getSelectedBlock(data, 'metadata')?.name
+			);
+		});
+
+		//
+		// 4.2. change to Row variation and check block card title
+		//
+		cy.setBlockVariation('group-row');
+
+		cy.get('.blockera-extension-block-card__title__input').should(
+			'not.have.class',
+			'is-edited'
+		);
+
+		cy.get('.blockera-extension-block-card__title__input span')
+			.should('have.text', '')
+			.should('have.attr', 'placeholder', 'Row');
+
+		getWPDataObject().then((data) => {
+			expect(undefined).to.be.equal(
+				getSelectedBlock(data, 'metadata')?.name
+			);
+		});
+
+		//
+		// 4.3. change to block name and check block card title
+		//
+
+		cy.get('.blockera-extension-block-card__title__input span').click();
+
+		cy.get('.blockera-extension-block-card__title__input span').type(
+			'New custom group name'
+		);
+
+		cy.get('.blockera-extension-block-card__title__input span').blur();
+
+		cy.get('.blockera-extension-block-card__title__input').should(
+			'have.class',
+			'is-edited'
+		);
+
+		cy.get('.blockera-extension-block-card__title__input span').should(
+			'have.text',
+			'New custom group name'
+		);
+
+		getWPDataObject().then((data) => {
+			expect('New custom group name').to.be.equal(
+				getSelectedBlock(data, 'metadata')?.name
+			);
+		});
+
+		//
+		// 4.4. switch variation and check block card title
+		//
+		cy.setBlockVariation('group-stack');
+
+		cy.get('.blockera-extension-block-card__title__input').should(
+			'have.class',
+			'is-edited'
+		);
+
+		cy.get('.blockera-extension-block-card__title__input span').should(
+			'have.text',
+			'New custom group name'
+		);
+
+		getWPDataObject().then((data) => {
+			expect('New custom group name').to.be.equal(
+				getSelectedBlock(data, 'metadata')?.name
+			);
+		});
+
+		//
+		// 4.5. remove block name and check block card title
+		//
+		cy.get('.blockera-extension-block-card__title__input span').click();
+
+		cy.get('.blockera-extension-block-card__title__input span').type(
+			'{esc}'
+		);
+
+		cy.get('.blockera-extension-block-card__title__input').should(
+			'not.have.class',
+			'is-edited'
+		);
+
+		cy.get('.blockera-extension-block-card__title__input span')
+			.should('have.text', '')
+			.should('have.attr', 'placeholder', 'Stack');
+
+		getWPDataObject().then((data) => {
+			expect(undefined).to.be.equal(
+				getSelectedBlock(data, 'metadata')?.name
+			);
+		});
+
+		//
+		// 4.6. change variation and check block card title
+		//
+		cy.setBlockVariation('group-grid');
+
+		cy.get('.blockera-extension-block-card__title__input').should(
+			'not.have.class',
+			'is-edited'
+		);
+
+		cy.get('.blockera-extension-block-card__title__input span')
+			.should('have.text', '')
+			.should('have.attr', 'placeholder', 'Grid');
+
+		getWPDataObject().then((data) => {
+			expect(undefined).to.be.equal(
+				getSelectedBlock(data, 'metadata')?.name
+			);
+		});
 	});
 });


### PR DESCRIPTION
- [x] Inline Block Renaming from the Block Card [[Feature request](https://community.blockera.ai/feature-request-1rsjg2ck/post/block-renaming-quick-block-renaming-from-the-block-card-j7XmvUiOTj36VFn)]
   - [x] inline edit by browser level + flexible width (use html content editable to make editing element with autosize)
   - [x] Placeholder
   - [x] `Esc` key to clear while editing
   - [x] `Enter` to submit and changing focus
   - [x] Design should be like feature label
   - [x] spell checking should be enabled only when title has focus
   - [x] escape content while pasting
- [x] E2E tests to check renaming functionality
- [x] E2E tests to check block renaming + block variations compatibility
- [x] E2E tests for paste