### PR TITLE
Feat: implements the Custom CSS feature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
 				"@blockera/telemetry": "file:packages/telemetry",
 				"@blockera/utils": "file:packages/utils",
 				"@blockera/wordpress": "file:packages/wordpress",
+				"@monaco-editor/react": "^4.7.0",
 				"@wordpress/icons": "^10.0.0",
 				"fast-deep-equal": "^3.1.3",
 				"fast-memoize": "^2.5.2",
@@ -4525,6 +4526,27 @@
 			"peerDependencies": {
 				"@types/react": ">=16",
 				"react": ">=16"
+			}
+		},
+		"node_modules/@monaco-editor/loader": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.5.0.tgz",
+			"integrity": "sha512-hKoGSM+7aAc7eRTRjpqAZucPmoNOC4UUbknb/VNoTkEIkCPhqV8LfbsgM1webRM7S/z21eHEx9Fkwx8Z/C/+Xw==",
+			"dependencies": {
+				"state-local": "^1.0.6"
+			}
+		},
+		"node_modules/@monaco-editor/react": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.7.0.tgz",
+			"integrity": "sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==",
+			"dependencies": {
+				"@monaco-editor/loader": "^1.5.0"
+			},
+			"peerDependencies": {
+				"monaco-editor": ">= 0.25.0 < 1",
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
 			}
 		},
 		"node_modules/@ndelangen/get-tarball": {
@@ -40000,6 +40022,12 @@
 				"node": "*"
 			}
 		},
+		"node_modules/monaco-editor": {
+			"version": "0.52.2",
+			"resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
+			"integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
+			"peer": true
+		},
 		"node_modules/mousetrap": {
 			"version": "1.6.5",
 			"resolved": "https://registry.npmjs.org/mousetrap/-/mousetrap-1.6.5.tgz",
@@ -46768,6 +46796,11 @@
 			"integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
 			"dev": true
 		},
+		"node_modules/state-local": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
+			"integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w=="
+		},
 		"node_modules/static-extend": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -50957,7 +50990,7 @@
 		},
 		"packages/blockera": {
 			"name": "@blockera/blockera",
-			"version": "1.2.1",
+			"version": "1.2.4",
 			"license": "ISC",
 			"engines": {
 				"node": ">=12"
@@ -50965,7 +50998,7 @@
 		},
 		"packages/blockera-admin": {
 			"name": "@blockera/blockera-admin",
-			"version": "1.1.0",
+			"version": "1.1.1",
 			"license": "ISC",
 			"engines": {
 				"node": ">=12"
@@ -50981,7 +51014,7 @@
 		},
 		"packages/blocks/core": {
 			"name": "@blockera/blocks-core",
-			"version": "1.1.0",
+			"version": "1.2.0",
 			"license": "ISC",
 			"engines": {
 				"node": ">=12"
@@ -50989,7 +51022,7 @@
 		},
 		"packages/bootstrap": {
 			"name": "@blockera/bootstrap",
-			"version": "1.0.0",
+			"version": "1.0.1",
 			"license": "ISC",
 			"engines": {
 				"node": ">=12"
@@ -51014,7 +51047,7 @@
 		},
 		"packages/controls": {
 			"name": "@blockera/controls",
-			"version": "1.1.1",
+			"version": "1.1.3",
 			"license": "ISC",
 			"engines": {
 				"node": ">=12"
@@ -51038,7 +51071,7 @@
 		},
 		"packages/dev-cypress": {
 			"name": "@blockera/dev-cypress",
-			"version": "1.0.0",
+			"version": "1.0.2",
 			"dev": true,
 			"license": "ISC",
 			"engines": {
@@ -51065,7 +51098,7 @@
 		},
 		"packages/editor": {
 			"name": "@blockera/editor",
-			"version": "1.2.1",
+			"version": "1.2.4",
 			"license": "ISC",
 			"engines": {
 				"node": ">=12"
@@ -51146,7 +51179,7 @@
 		},
 		"packages/wordpress": {
 			"name": "@blockera/wordpress",
-			"version": "1.1.0",
+			"version": "1.1.2",
 			"license": "ISC",
 			"engines": {
 				"node": ">=12"
@@ -54266,6 +54299,22 @@
 			"dev": true,
 			"requires": {
 				"@types/mdx": "^2.0.0"
+			}
+		},
+		"@monaco-editor/loader": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.5.0.tgz",
+			"integrity": "sha512-hKoGSM+7aAc7eRTRjpqAZucPmoNOC4UUbknb/VNoTkEIkCPhqV8LfbsgM1webRM7S/z21eHEx9Fkwx8Z/C/+Xw==",
+			"requires": {
+				"state-local": "^1.0.6"
+			}
+		},
+		"@monaco-editor/react": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.7.0.tgz",
+			"integrity": "sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==",
+			"requires": {
+				"@monaco-editor/loader": "^1.5.0"
 			}
 		},
 		"@ndelangen/get-tarball": {
@@ -81157,6 +81206,12 @@
 				"moment": "^2.29.4"
 			}
 		},
+		"monaco-editor": {
+			"version": "0.52.2",
+			"resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
+			"integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
+			"peer": true
+		},
 		"mousetrap": {
 			"version": "1.6.5",
 			"resolved": "https://registry.npmjs.org/mousetrap/-/mousetrap-1.6.5.tgz",
@@ -86149,6 +86204,11 @@
 			"resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
 			"integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
 			"dev": true
+		},
+		"state-local": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
+			"integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w=="
 		},
 		"static-extend": {
 			"version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
 		"@blockera/telemetry": "file:packages/telemetry",
 		"@blockera/utils": "file:packages/utils",
 		"@blockera/wordpress": "file:packages/wordpress",
+		"@monaco-editor/react": "^4.7.0",
 		"@wordpress/icons": "^10.0.0",
 		"fast-deep-equal": "^3.1.3",
 		"fast-memoize": "^2.5.2",

--- a/packages/controls/CHANGELOG.md
+++ b/packages/controls/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## Unreleased
 
 ### New Features
-- Implemented the `Code Control` component to allow developers to create code control for any languages.
+- Implemented inner `Code Control` component to allow developers to create code control for any languages.
+
 
 ## 1.1.3 (2025-04-12)
 

--- a/packages/controls/CHANGELOG.md
+++ b/packages/controls/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+### New Features
+- Implemented the `Code Control` component to allow developers to create code control for any languages.
+
 ## 1.1.3 (2025-04-12)
 
 ### Improvements

--- a/packages/controls/js/libs/code-control/index.js
+++ b/packages/controls/js/libs/code-control/index.js
@@ -15,7 +15,6 @@ import {
 	controlClassNames,
 	controlInnerClassNames,
 } from '@blockera/classnames';
-import { useLateEffect } from '@blockera/utils';
 
 /**
  * Internal dependencies
@@ -60,16 +59,8 @@ const CodeControl = ({
 	});
 
 	const [showPlaceholder, setShowPlaceholder] = useState(false);
-
 	const editorRef = useRef(null);
-
-	// update value if changed from outside
-	// force editor to update inside state
-	useLateEffect(() => {
-		if (editorRef?.current && editorRef?.current?.getValue() !== value) {
-			editorRef.current.setValue(value);
-		}
-	}, [value]);
+	const timeoutRef = useRef(null);
 
 	const labelProps = {
 		value,
@@ -135,7 +126,14 @@ const CodeControl = ({
 					defaultValue={value}
 					onChange={(newValue) => {
 						setShowPlaceholder(newValue === '');
-						setValue(newValue);
+
+						if (timeoutRef.current) {
+							clearTimeout(timeoutRef.current);
+						}
+
+						timeoutRef.current = setTimeout(() => {
+							setValue(newValue);
+						}, 500);
 					}}
 					theme={'blockera'}
 					options={{
@@ -169,6 +167,10 @@ const CodeControl = ({
 					}}
 					onMount={(editor: any) => {
 						editorRef.current = editor;
+
+						if (value !== editor.getValue()) {
+							editor.setValue(value);
+						}
 					}}
 				/>
 

--- a/packages/controls/js/libs/code-control/index.js
+++ b/packages/controls/js/libs/code-control/index.js
@@ -96,15 +96,13 @@ const CodeControl = ({
 								text={sprintf(
 									/* translators: $1%s is a CSS selector, $2%s is ID. */
 									__(
-										'Use %1$s or %2$s to target current block.',
+										'Use %1$s to target current block.',
 										'blockera'
 									),
-									'{.block}',
-									'{#block}'
+									'{.block}'
 								)}
 								replacements={{
 									'.block': <code>.block</code>,
-									'#block': <code>#block</code>,
 								}}
 							/>
 						</p>

--- a/packages/controls/js/libs/code-control/index.js
+++ b/packages/controls/js/libs/code-control/index.js
@@ -6,7 +6,7 @@
 import { __, sprintf } from '@wordpress/i18n';
 import type { MixedElement } from 'react';
 import { useState, useRef } from '@wordpress/element';
-// import { Editor } from '@monaco-editor/react';
+import { Editor } from '@monaco-editor/react';
 
 /**
  * Blockera dependencies
@@ -27,10 +27,10 @@ import type { CodeControlProps } from './types';
 
 const CodeControl = ({
 	lang = 'css',
-	// width = '',
-	// height = '',
+	width = '',
+	height = '',
 	placeholder = '',
-	// editable = true,
+	editable = true,
 	description = '',
 	//
 	id,
@@ -48,7 +48,7 @@ const CodeControl = ({
 }: CodeControlProps): MixedElement => {
 	const {
 		value,
-		//setValue,
+		setValue,
 		attribute,
 		blockName,
 		resetToDefault,
@@ -59,8 +59,7 @@ const CodeControl = ({
 		defaultValue,
 	});
 
-	// setShowPlaceholder
-	const [showPlaceholder] = useState(true);
+	const [showPlaceholder, setShowPlaceholder] = useState(false);
 
 	const editorRef = useRef(null);
 
@@ -131,7 +130,7 @@ const CodeControl = ({
 	return (
 		<BaseControl columns={columns} controlName={field} {...labelProps}>
 			<div className={controlClassNames('code', className)}>
-				{/* <Editor
+				<Editor
 					width={width || 250}
 					height={height || 200}
 					defaultLanguage={lang}
@@ -173,7 +172,7 @@ const CodeControl = ({
 					onMount={(editor: any) => {
 						editorRef.current = editor;
 					}}
-				/> */}
+				/>
 
 				{showPlaceholder && (
 					<div

--- a/packages/controls/js/libs/code-control/index.js
+++ b/packages/controls/js/libs/code-control/index.js
@@ -161,6 +161,57 @@ const CodeControl = ({
 									'editorLineNumber.foreground': '#7d7d7d75',
 								},
 							});
+
+							// Add custom completion provider for CSS
+							monaco.languages.registerCompletionItemProvider(
+								'css',
+								{
+									provideCompletionItems: (
+										model,
+										position
+									) => {
+										const textUntilPosition =
+											model.getValueInRange({
+												startLineNumber:
+													position.lineNumber,
+												startColumn: 1,
+												endLineNumber:
+													position.lineNumber,
+												endColumn: position.column,
+											});
+
+										// Check if user is typing a selector
+										if (
+											textUntilPosition
+												.trim()
+												.endsWith('.')
+										) {
+											return {
+												suggestions: [
+													{
+														label: '.block',
+														kind: monaco.languages
+															.CompletionItemKind
+															.Class,
+														insertText: '.block',
+														documentation: __(
+															'Target the current block',
+															'blockera'
+														),
+														detail: __(
+															'Blockera Block Selector',
+															'blockera'
+														),
+													},
+												],
+											};
+										}
+
+										return { suggestions: [] };
+									},
+								}
+							);
+
 							setShowPlaceholder(value === '');
 							monaco.blockeraInitialised = true;
 						}

--- a/packages/controls/js/libs/code-control/index.js
+++ b/packages/controls/js/libs/code-control/index.js
@@ -193,7 +193,12 @@ const CodeControl = ({
 														kind: monaco.languages
 															.CompletionItemKind
 															.Class,
-														insertText: '.block',
+														insertText:
+															'.block {\n\t$0\n}',
+														insertTextRules:
+															monaco.languages
+																.CompletionItemInsertTextRule
+																.InsertAsSnippet,
 														documentation: __(
 															'Target the current block',
 															'blockera'
@@ -202,6 +207,18 @@ const CodeControl = ({
 															'Blockera Block Selector',
 															'blockera'
 														),
+														sortText: '.block',
+														range: {
+															startLineNumber:
+																position.lineNumber,
+															startColumn:
+																position.column -
+																1,
+															endLineNumber:
+																position.lineNumber,
+															endColumn:
+																position.column,
+														},
 													},
 												],
 											};

--- a/packages/controls/js/libs/code-control/style.scss
+++ b/packages/controls/js/libs/code-control/style.scss
@@ -4,16 +4,10 @@
 	gap: 10px;
 	position: relative;
 
-	&::before {
-		content: "";
-		height: 100px;
-		display: block;
-		background: #eaeaea;
-	}
-
 	& > section {
 		background-color: #f6f6f6;
 		border-radius: 2px;
+    	padding-top: 5px;
 	}
 
 	.blockera-control-code-control__description {
@@ -39,7 +33,7 @@
 
 	.blockera-control-code-control__placeholder {
 		position: absolute;
-		top: 15px;
+		top: 5px;
 		left: 28px;
 		right: 10px;
 		color: #7d8a99;

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Automated Tests
 - Added E2E tests to check inline block renaming.
 - Added E2E test to check inline block renaming for blocks with variations.
+- Added E2E tests to check Custom CSS feature.
 
 
 ## 1.2.4 (2025-04-16)

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -5,7 +5,9 @@
 
 ### New Features
 - Inline block renaming by clicking on block card [[🔗 Feature request](https://community.blockera.ai/feature-request-1rsjg2ck/post/block-renaming-quick-block-renaming-from-the-block-card-j7XmvUiOTj36VFn)]
-- Supported the `Custom CSS` feature for each all blocks.
+- Custom CSS Code Feature: Allows you to add custom CSS codes per block. [Pro Feature]
+- Smart autocomplete suggestions for CSS variables in code editor by typing `--`.
+- Smart `.block` autocomplete for current block selector in code editor.
 
 
 ### Improvements

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### New Features
 - Inline block renaming by clicking on block card [[🔗 Feature request](https://community.blockera.ai/feature-request-1rsjg2ck/post/block-renaming-quick-block-renaming-from-the-block-card-j7XmvUiOTj36VFn)]
+- Supported the `Custom CSS` feature for each all blocks.
 
 
 ### Improvements

--- a/packages/editor/js/extensions/components/block-base.js
+++ b/packages/editor/js/extensions/components/block-base.js
@@ -314,7 +314,7 @@ export const BlockBase: ComponentType<any> = memo((): Element<any> | null => {
 		blockName: name,
 		currentAttributes,
 		defaultAttributes,
-		customCss: attributes.blockeraCustomCSS.replace(
+		customCss: attributes?.blockeraCustomCSS?.value?.replace(
 			/(.|#)block/gi,
 			`#block-${clientId}`
 		),

--- a/packages/editor/js/extensions/components/block-base.js
+++ b/packages/editor/js/extensions/components/block-base.js
@@ -314,6 +314,10 @@ export const BlockBase: ComponentType<any> = memo((): Element<any> | null => {
 		blockName: name,
 		currentAttributes,
 		defaultAttributes,
+		customCss: attributes.blockeraCustomCSS.replace(
+			/(.|#)block/gi,
+			`#block-${clientId}`
+		),
 		activeDeviceType: getDeviceType(),
 	};
 

--- a/packages/editor/js/extensions/libs/custom-style/extension.js
+++ b/packages/editor/js/extensions/libs/custom-style/extension.js
@@ -68,8 +68,10 @@ export const CustomStyleExtension: ComponentType<CustomStyleExtensionProps> =
 					icon={<Icon icon="extension-custom-style" />}
 					className={extensionClassNames('custom-style')}
 					isChanged={
+						!initialOpen &&
+						values.blockeraCustomCSS !== '' &&
 						values.blockeraCustomCSS !==
-						attributes.blockeraCustomCSS.default
+							attributes.blockeraCustomCSS.default
 					}
 				>
 					<EditorFeatureWrapper

--- a/packages/editor/js/extensions/libs/custom-style/test/custom-css.e2e.cy.js
+++ b/packages/editor/js/extensions/libs/custom-style/test/custom-css.e2e.cy.js
@@ -1,0 +1,21 @@
+import {
+	createPost,
+	openSettingsPanel,
+} from '@blockera/dev-cypress/js/helpers';
+
+describe('Custom CSS', () => {
+	beforeEach(() => {
+		createPost();
+
+		cy.getBlock('default').type('This is test paragraph', { delay: 0 });
+		cy.getByDataTest('style-tab').click();
+	});
+
+	it('should disable custom CSS code editor when block editing in free plugin', () => {
+		openSettingsPanel('Custom CSS');
+
+		cy.getParentContainer('Custom CSS Code').within(() => {
+			cy.get('.monaco-editor').should('have.css', 'user-select', 'none');
+		});
+	});
+});

--- a/packages/editor/js/style-engine/components/block-style.js
+++ b/packages/editor/js/style-engine/components/block-style.js
@@ -12,7 +12,10 @@ import type { BlockStyleProps } from './types';
 import { StateStyle } from '../';
 import { useExtensionsStore } from '../../hooks/use-extensions-store';
 
-export const BlockStyle = (props: BlockStyleProps): MixedElement => {
+export const BlockStyle = ({
+	customCss,
+	...props
+}: BlockStyleProps): MixedElement => {
 	const {
 		config,
 		currentBlock,
@@ -31,6 +34,7 @@ export const BlockStyle = (props: BlockStyleProps): MixedElement => {
 
 	return (
 		<style>
+			{customCss}
 			<StateStyle
 				{...{
 					...props,

--- a/packages/editor/js/style-engine/components/types/index.js
+++ b/packages/editor/js/style-engine/components/types/index.js
@@ -15,6 +15,7 @@ export type MediaQueryProps = {
 };
 
 export type BlockStyleProps = {
+	customCss?: string,
 	clientId: string,
 	supports: Object,
 	blockName: string,

--- a/packages/wordpress/php/RenderBlock/V1/Render.php
+++ b/packages/wordpress/php/RenderBlock/V1/Render.php
@@ -164,12 +164,22 @@ class Render {
         $cache_data = blockera_get_block_cache($cache_key);
         // Get cache validate result.
         $cache_validate = ! empty($cache_data['css']) && ! empty($cache_data['hash']) && ! empty($cache_data['classname']);
+		// Get normalized blockera block unique css classname.
+        $unique_class_name = blockera_get_normalized_selector($need_to_update_html ? $blockera_class_name : $attributes['className']);
 
         // Validate cache data.
         if ($cache_validate && $hash === $cache_data['hash'] && $this->cache_status) {
 
+			$css = $cache_data['css'];
+
+			// If custom css is set, add it to the block css.
+			if (! empty($attributes['blockeraCustomCSS'])) {
+
+				$css .= preg_replace('/(.|#)block/i', $unique_class_name, $attributes['blockeraCustomCSS']);
+			}
+
             // Print css into inline style on "wp_head" action occur.
-            blockera_add_inline_css($cache_data['css']);
+            blockera_add_inline_css($css);
 
             if ($need_to_update_html) {
 
@@ -179,9 +189,6 @@ class Render {
 
             return $html;
         }
-
-        // Get normalized blockera block unique css classname.
-        $unique_class_name = blockera_get_normalized_selector($need_to_update_html ? $blockera_class_name : $attributes['className']);
 
         /**
          * Get parser object.
@@ -193,6 +200,12 @@ class Render {
 
         // Computation css rules for current block by server side style engine...
         $computed_css_rules = $parser->getCss(compact('block', 'unique_class_name'));
+
+		// If custom css is set, add it to the block css.
+		if (! empty($attributes['blockeraCustomCSS']['value'])) {
+
+			$computed_css_rules .= preg_replace('/(.|#)block/i', $unique_class_name, $attributes['blockeraCustomCSS']['value']);
+		}
 
         // Print css into inline style on "wp_head" action occur.
         blockera_add_inline_css($computed_css_rules);

--- a/packages/wordpress/php/RenderBlock/V2/Transpiler.php
+++ b/packages/wordpress/php/RenderBlock/V2/Transpiler.php
@@ -230,6 +230,11 @@ class Transpiler {
 						'blockera_class_name' => $blockera_class_name,
 					]
 				);
+
+				// If custom css is set, add it to the block css stack.
+				if (! empty($block['attrs']['blockeraCustomCSS']['value']) && ! in_array($block['attrs']['blockeraCustomCSS']['value'], $this->styles, true)) {
+					$this->styles[] = preg_replace('/(.|#)block/i', $unique_class_name, $block['attrs']['blockeraCustomCSS']['value']);
+				}
 			}
 		}
 


### PR DESCRIPTION
- [x] fix code control issues
- [x] append blockera custom css attribute value into editor document to apply css styles.
- [x] It should Supports the blockera custom css feature in style engine v1 and v2.
- [x] We should add e2e tests to wrap all states of this feature.   
- [x] Autocomplete for `.block` @aliaghdam 
- [x] Autocomplete for CSS variables inside css editor by typing `--` or `var(--` @aliaghdam 