### PR TITLE
Fix: Double preview button in translated languages

### DIFF
--- a/packages/controls/js/libs/code-control/index.js
+++ b/packages/controls/js/libs/code-control/index.js
@@ -392,7 +392,7 @@ const CodeControl = ({
 															.CompletionItemKind
 															.Class,
 														insertText:
-															'.block {\n\t$0\n}',
+															'.block {\n\t$0\n}\n',
 														insertTextRules:
 															monaco.languages
 																.CompletionItemInsertTextRule
@@ -424,7 +424,7 @@ const CodeControl = ({
 															.CompletionItemKind
 															.Class,
 														insertText:
-															'.block:hover {\n\t$0\n}',
+															'.block:hover {\n\t$0\n}\n',
 														insertTextRules:
 															monaco.languages
 																.CompletionItemInsertTextRule

--- a/packages/controls/js/libs/code-control/index.js
+++ b/packages/controls/js/libs/code-control/index.js
@@ -488,6 +488,17 @@ const CodeControl = ({
 						if (value !== editor.getValue()) {
 							editor.setValue(value);
 						}
+
+						// Set cursor position between curly braces for CSS
+						if (lang === 'css' && value === '.block {\n    \n}\n') {
+							const position = editor.getPosition();
+							if (position) {
+								editor.setPosition({
+									lineNumber: 2,
+									column: 4,
+								});
+							}
+						}
 					}}
 				/>
 

--- a/packages/controls/js/libs/code-control/index.js
+++ b/packages/controls/js/libs/code-control/index.js
@@ -402,10 +402,43 @@ const CodeControl = ({
 															'blockera'
 														),
 														detail: __(
-															'Blockera Block Selector',
+															'Current Block',
 															'blockera'
 														),
 														sortText: '.block',
+														range: {
+															startLineNumber:
+																position.lineNumber,
+															startColumn:
+																position.column -
+																1,
+															endLineNumber:
+																position.lineNumber,
+															endColumn:
+																position.column,
+														},
+													},
+													{
+														label: '.block:hover',
+														kind: monaco.languages
+															.CompletionItemKind
+															.Class,
+														insertText:
+															'.block:hover {\n\t$0\n}',
+														insertTextRules:
+															monaco.languages
+																.CompletionItemInsertTextRule
+																.InsertAsSnippet,
+														documentation: __(
+															'Target the current block on hover',
+															'blockera'
+														),
+														detail: __(
+															'Current Block on Hover',
+															'blockera'
+														),
+														sortText:
+															'.block:hover',
 														range: {
 															startLineNumber:
 																position.lineNumber,

--- a/packages/controls/js/libs/code-control/style.scss
+++ b/packages/controls/js/libs/code-control/style.scss
@@ -6,8 +6,8 @@
 
 	& > section {
 		background-color: #f6f6f6;
-		border-radius: 2px;
-    	padding-top: 5px;
+		border-radius: 5px;
+    	padding-top: 10px;
 	}
 
 	.blockera-control-code-control__description {
@@ -33,7 +33,7 @@
 
 	.blockera-control-code-control__placeholder {
 		position: absolute;
-		top: 5px;
+		top: 10px;
 		left: 28px;
 		right: 10px;
 		color: #7d8a99;
@@ -46,6 +46,15 @@
 		line-height: 20px;
 		letter-spacing: 0;
 		pointer-events: none;
+	}
+
+	.monaco-editor {
+		border-radius: 5px;
+
+		.overflow-guard {
+			border-bottom-right-radius: 5px;
+			border-bottom-left-radius: 5px;
+		}
 	}
 }
 

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -13,13 +13,16 @@
 
 
 ### Improvements
+- Aspect ratio feature improved to smartly set the width and height while switching to custom ratio.
 - Improve block card design.
 - Improve overall codes.
+
 
 ### Automated Tests
 - Added E2E tests to check inline block renaming.
 - Added E2E test to check inline block renaming for blocks with variations.
 - Added E2E tests to check Custom CSS feature.
+- Aspect ratio tests updated for latest updates.
 
 
 ## 1.2.4 (2025-04-16)

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Bug Fixes
 - Flex layout feature not working properly on breakpoints reported by Davor Jovanović 🙏🏼 [[🔗 Bug](https://community.blockera.ai/bugs-mdhyb8nc/post/block-row-doesn-t-accept-justify-content-center-bZeVoRwgQ5xhnbm)]
+- Duplicate preview button on non-English websites reported by Hoang 🙏🏼.
 
 ### New Features
 - Inline block renaming by clicking on block card [[🔗 Feature request](https://community.blockera.ai/feature-request-1rsjg2ck/post/block-renaming-quick-block-renaming-from-the-block-card-j7XmvUiOTj36VFn)]

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Custom CSS Code Feature: Allows you to add custom CSS codes per block. [Pro Feature]
 - Smart autocomplete suggestions for CSS variables in code editor by typing `--`.
 - Smart `.block` autocomplete for current block selector in code editor.
+- Smart `.block:hover` autocomplete for current block hover state in code editor.
 
 
 ### Improvements

--- a/packages/editor/js/canvas-editor/bootstrap.js
+++ b/packages/editor/js/canvas-editor/bootstrap.js
@@ -24,7 +24,7 @@ export const bootstrapCanvasEditor = (): void | Object => {
 	const observerPlugin = 'blockera-canvas-editor-observer';
 
 	const { version } = getEntity('wp');
-	const { header, previewDropdown, postPreviewElement } = getTargets(version);
+	const { header } = getTargets(version);
 
 	const registry = () => {
 		registerPlugin(observerPlugin, {
@@ -33,6 +33,13 @@ export const bootstrapCanvasEditor = (): void | Object => {
 
 				// eslint-disable-next-line react-hooks/rules-of-hooks
 				useEffect(() => {
+					// Add class to body to indicate that the canvas editor is enabled.
+					if (document.body) {
+						document.body.classList.add(
+							'blockera-canvas-editor-enabled'
+						);
+					}
+
 					if (
 						!document.querySelector(componentSelector) &&
 						!cache.get(componentSelector)
@@ -40,13 +47,9 @@ export const bootstrapCanvasEditor = (): void | Object => {
 						cache.set(componentSelector, true);
 
 						new IntersectionObserverRenderer(
-							'.editor-header__center',
+							header,
 							(): MixedElement => (
 								<CanvasEditor
-									{...{
-										previewDropdown,
-										postPreviewElement,
-									}}
 									target={document.querySelector(header)}
 								/>
 							),

--- a/packages/editor/js/canvas-editor/components/preview.js
+++ b/packages/editor/js/canvas-editor/components/preview.js
@@ -6,7 +6,6 @@
 import { __ } from '@wordpress/i18n';
 import type { MixedElement } from 'react';
 import { useSelect } from '@wordpress/data';
-import { useEffect } from '@wordpress/element';
 
 /**
  * Blockera dependencies
@@ -18,7 +17,6 @@ import { controlInnerClassNames } from '@blockera/classnames';
 /**
  * Internal dependencies
  */
-import { getTargets } from '../helpers';
 import { PostPreviewButton } from './post-preview-button';
 
 export const Preview = (): MixedElement => {
@@ -30,7 +28,6 @@ export const Preview = (): MixedElement => {
 		previewLink,
 		isSavablePost,
 		currentPostLink,
-		previewDropdown,
 	} = useSelect((select) => {
 		const {
 			getPermalink,
@@ -42,16 +39,9 @@ export const Preview = (): MixedElement => {
 			getEditedPostPreviewLink,
 		} = select('core/editor') || {};
 		const { getPostType } = select('core');
-
 		const postType = getPostType(getCurrentPostType('type'));
 
-		const { getEntity } = select('blockera/data') || {};
-		const { version } = getEntity('wp');
-
-		const { previewDropdown } = getTargets(version);
-
 		return {
-			previewDropdown,
 			permalink: getPermalink(),
 			postId: getCurrentPostId(),
 			isPublished: isCurrentPostPublished(),
@@ -68,18 +58,6 @@ export const Preview = (): MixedElement => {
 		!isPublished || !permalink
 			? previewLink || currentPostLink
 			: currentPostLink;
-
-	// To hidden WordPress original post-preview-button.
-	useEffect(() => {
-		const originPreviews = document.querySelectorAll(previewDropdown);
-
-		if (originPreviews.length) {
-			originPreviews.forEach((preview) => {
-				preview.style.display = 'none';
-			});
-		}
-		// eslint-disable-next-line
-	}, [href]);
 
 	const previewButton = (
 		<PostPreviewButton

--- a/packages/editor/js/canvas-editor/helpers.js
+++ b/packages/editor/js/canvas-editor/helpers.js
@@ -26,9 +26,6 @@ export const getTargets = (version: string): GetTarget => {
 
 	const targets = {
 		header: '.editor-header__center',
-		previewDropdown:
-			'.editor-preview-dropdown, a.components-button[aria-label="View Post"], a.components-button[aria-label="View Page"], .editor-header__settings > a[target="_blank"]:first-child',
-		postPreviewElement: '.editor-header__settings a[target|="wp-preview"]',
 	};
 
 	// For WordPress version equals or bigger than 6.6.1 version.
@@ -45,8 +42,5 @@ export const getTargets = (version: string): GetTarget => {
 		header: isLoadedSiteEditor()
 			? '.edit-site-header-edit-mode__center'
 			: '.edit-post-header__center',
-		postPreviewElement:
-			'a[aria-label="View Post"], a[aria-label="View Page"]',
-		previewDropdown: 'div.edit-site-header-edit-mode__preview-options',
 	};
 };

--- a/packages/editor/js/canvas-editor/helpers.js
+++ b/packages/editor/js/canvas-editor/helpers.js
@@ -28,7 +28,7 @@ export const getTargets = (version: string): GetTarget => {
 		header: '.editor-header__center',
 		previewDropdown:
 			'.editor-preview-dropdown, a.components-button[aria-label="View Post"], a.components-button[aria-label="View Page"]',
-		postPreviewElement: '.editor-header__post-preview-button + a',
+		postPreviewElement: '.editor-header__settings a[target|="wp-preview"]',
 	};
 
 	// For WordPress version equals or bigger than 6.6.1 version.

--- a/packages/editor/js/canvas-editor/helpers.js
+++ b/packages/editor/js/canvas-editor/helpers.js
@@ -27,7 +27,7 @@ export const getTargets = (version: string): GetTarget => {
 	const targets = {
 		header: '.editor-header__center',
 		previewDropdown:
-			'.editor-preview-dropdown, a.components-button[aria-label="View Post"], a.components-button[aria-label="View Page"]',
+			'.editor-preview-dropdown, a.components-button[aria-label="View Post"], a.components-button[aria-label="View Page"], .editor-header__settings > a[target="_blank"]:first-child',
 		postPreviewElement: '.editor-header__settings a[target|="wp-preview"]',
 	};
 

--- a/packages/editor/js/canvas-editor/index.js
+++ b/packages/editor/js/canvas-editor/index.js
@@ -3,9 +3,8 @@
 /**
  * External dependencies
  */
-import { select } from '@wordpress/data';
 import type { MixedElement } from 'react';
-import { useRef, useEffect, createPortal } from '@wordpress/element';
+import { createPortal } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -14,37 +13,10 @@ import { Breakpoints } from './components';
 
 export const CanvasEditor = ({
 	target,
-	previewDropdown,
-	postPreviewElement,
 }: {
-	previewDropdown: string,
-	postPreviewElement: string,
 	target: HTMLElement | null,
 }): MixedElement => {
-	const ref = useRef(null);
-	const { getSelectedBlock } = select('core/block-editor');
-	const selectedBlock = getSelectedBlock();
-
 	const className = 'blockera-canvas-breakpoints';
-
-	useEffect(() => {
-		ref.current = {
-			postPreviewElement: document.querySelector(postPreviewElement),
-			previewDropdown: document.querySelectorAll(previewDropdown),
-		};
-
-		if (ref.current.postPreviewElement) {
-			ref.current.postPreviewElement.style.display = 'none';
-		}
-		if (ref.current.previewDropdown.length) {
-			ref.current.previewDropdown.forEach((previewElement) => {
-				if (previewElement) {
-					previewElement.style.display = 'none';
-				}
-			});
-		}
-		// eslint-disable-next-line
-	}, [selectedBlock]);
 
 	if (!target) {
 		return <></>;

--- a/packages/editor/js/canvas-editor/style.scss
+++ b/packages/editor/js/canvas-editor/style.scss
@@ -1,3 +1,12 @@
+.blockera-canvas-editor-enabled {
+
+	.editor-header__settings > a[target="_blank"]:first-child,
+	.editor-header__settings > a[target="_blank"]:first-child + div,
+	.editor-header__settings > button:first-child + div {
+		display: none;
+	}
+}
+
 #blockera-canvas-editor {
 	display: flex;
 	justify-content: space-between;

--- a/packages/editor/js/canvas-editor/test/get-targets.spec.js
+++ b/packages/editor/js/canvas-editor/test/get-targets.spec.js
@@ -5,26 +5,17 @@ describe('getTargets api testing', () => {
 	it('should be retrieve targets object for wp version greater equal with 6.6.1', () => {
 		expect({
 			header: '.editor-header__center',
-			previewDropdown:
-				'.editor-preview-dropdown, a.components-button[aria-label="View Post"], a.components-button[aria-label="View Page"]',
-			postPreviewElement: '.editor-header__post-preview-button + a',
 		}).toStrictEqual(getTargets('6.6.1'));
 	});
 	it('should be retrieve targets object for wp 6.6.3-alpha-59007 version', () => {
 		expect({
 			header: '.editor-header__center',
-			previewDropdown:
-				'.editor-preview-dropdown, a.components-button[aria-label="View Post"], a.components-button[aria-label="View Page"]',
-			postPreviewElement: '.editor-header__post-preview-button + a',
 		}).toStrictEqual(getTargets('6.6.3-alpha-59007'));
 	});
 
 	it('should be retrieve targets object for wp 6.7.3-beta-12345 version', () => {
 		expect({
 			header: '.editor-header__center',
-			previewDropdown:
-				'.editor-preview-dropdown, a.components-button[aria-label="View Post"], a.components-button[aria-label="View Page"]',
-			postPreviewElement: '.editor-header__post-preview-button + a',
 		}).toStrictEqual(getTargets('6.7.3-beta-12345'));
 	});
 
@@ -33,9 +24,6 @@ describe('getTargets api testing', () => {
 			header: isLoadedSiteEditor()
 				? '.edit-site-header-edit-mode__center'
 				: '.edit-post-header__center',
-			postPreviewElement:
-				'a[aria-label="View Post"], a[aria-label="View Page"]',
-			previewDropdown: 'div.edit-site-header-edit-mode__preview-options',
 		}).toStrictEqual(getTargets('6.6'));
 	});
 });

--- a/packages/editor/js/canvas-editor/types/index.js
+++ b/packages/editor/js/canvas-editor/types/index.js
@@ -2,6 +2,4 @@
 
 export type GetTarget = {
 	header: string,
-	previewDropdown: string,
-	postPreviewElement: string,
 };

--- a/packages/editor/js/extensions/libs/size/components/aspect-ratio.js
+++ b/packages/editor/js/extensions/libs/size/components/aspect-ratio.js
@@ -157,11 +157,47 @@ export const AspectRatio: ComponentType<any> = memo(
 								}
 							);
 						} else {
+							newValue = {
+								val: newValue,
+							};
+
+							// remove the width and height
+							if (newValue.val !== 'custom') {
+								newValue = {
+									...newValue,
+									width: '',
+									height: '',
+								};
+							} else if (
+								newValue.val === 'custom' &&
+								value?.val &&
+								value.val !== ''
+							) {
+								//
+								// Smart width and height detection from old value and adding it to width and height
+								//
+								const [width, height] = value.val.split('/');
+
+								if (width && height) {
+									newValue = {
+										...newValue,
+										width: width.trim(),
+										height: height.trim(),
+									};
+								} else if (width && !height) {
+									newValue = {
+										...newValue,
+										width: width.trim(),
+										height: width.trim(),
+									};
+								}
+							}
+
 							handleOnChangeAttributes(
 								'blockeraRatio',
 								{
 									...ratio,
-									val: newValue,
+									...newValue,
 								},
 								{ ref }
 							);

--- a/packages/editor/js/extensions/libs/size/test/aspect-ratio.compatibility.e2e.cy.js
+++ b/packages/editor/js/extensions/libs/size/test/aspect-ratio.compatibility.e2e.cy.js
@@ -130,10 +130,16 @@ describe('Aspect Ratio → WP Compatibility', () => {
 				cy.get('@aspectSelect').select('custom', { force: true });
 
 				// set width
-				cy.get('input').eq(0).type('2');
+				cy.get('input')
+					.eq(0)
+					.clear({ fore: true })
+					.type('2', { force: true });
 
 				// set height
-				cy.get('input').eq(1).type('3');
+				cy.get('input')
+					.eq(1)
+					.clear({ force: true })
+					.type('3', { force: true });
 			});
 
 			getWPDataObject().then((data) => {
@@ -300,10 +306,16 @@ describe('Aspect Ratio → WP Compatibility', () => {
 				cy.get('@aspectSelect').select('custom', { force: true });
 
 				// set width
-				cy.get('input').eq(0).type('2');
+				cy.get('input')
+					.eq(0)
+					.clear({ force: true })
+					.type('2', { force: true });
 
 				// set height
-				cy.get('input').eq(1).type('3');
+				cy.get('input')
+					.eq(1)
+					.clear({ force: true })
+					.type('3', { force: true });
 			});
 
 			getWPDataObject().then((data) => {

--- a/packages/editor/js/extensions/libs/size/test/aspect-ratio.e2e.cy.js
+++ b/packages/editor/js/extensions/libs/size/test/aspect-ratio.e2e.cy.js
@@ -45,8 +45,55 @@ describe('Aspect Ratio → Functionality', () => {
 		// Custom
 		cy.getParentContainer('Aspect Ratio').within(() => {
 			cy.get('select').select('custom');
-			cy.get('input').eq(0).type(2);
-			cy.get('input').eq(1).type(5);
+		});
+
+		// Check store
+		getWPDataObject().then((data) => {
+			expect({
+				val: 'custom',
+				width: '1',
+				height: '1',
+			}).to.be.deep.equal(getSelectedBlock(data, 'blockeraRatio'));
+		});
+
+		// Standard 4:3
+		cy.getParentContainer('Aspect Ratio').within(() => {
+			cy.get('select').select('4/3', { force: true });
+		});
+
+		// Check store
+		getWPDataObject().then((data) => {
+			expect({
+				val: '4/3',
+				width: '',
+				height: '',
+			}).to.be.deep.equal(getSelectedBlock(data, 'blockeraRatio'));
+		});
+
+		// Custom
+		cy.getParentContainer('Aspect Ratio').within(() => {
+			cy.get('select').select('custom');
+		});
+
+		// Check store
+		getWPDataObject().then((data) => {
+			expect({
+				val: 'custom',
+				width: '4',
+				height: '3',
+			}).to.be.deep.equal(getSelectedBlock(data, 'blockeraRatio'));
+		});
+
+		// set custom ratio
+		cy.getParentContainer('Aspect Ratio').within(() => {
+			cy.get('input')
+				.eq(0)
+				.clear({ force: true })
+				.type(2, { force: true });
+			cy.get('input')
+				.eq(1)
+				.clear({ force: true })
+				.type(5, { force: true });
 		});
 
 		// Check block


### PR DESCRIPTION
- [x] In non-english websites the preview button is duplicate 
   - [x] check in wp < 6.6
- [x] improve code control to set cursor in center of default value
- [x] add `.block:hover` to code control suggestions 