### PR TITLE
Sync package from blockera-pro Repo

### DIFF
--- a/packages/dev-cypress/blockera-folder-sync.json
+++ b/packages/dev-cypress/blockera-folder-sync.json
@@ -4,7 +4,8 @@
 	"dependent": {
 		"repositories": [
 			"https://github.com/blockeraai/blockera.git",
-			"https://github.com/blockeraai/blockera-pro.git"
+			"https://github.com/blockeraai/blockera-pro.git",
+			"https://github.com/blockeraai/blockera-site-toolkit.git"
 		]
 	}
 }


### PR DESCRIPTION
This PR syncs the package from the [blockera-pro](https://github.com/blockeraai/blockera-pro) repository.