### PR TITLE
ci: Host PR Playground demo zips on GitHub instead of FTP

### DIFF
--- a/.github/workflows/create-demo-attachments.yml
+++ b/.github/workflows/create-demo-attachments.yml
@@ -2,6 +2,7 @@ name: Create Demo and Attachment Files
 
 on:
     pull_request:
+        types: [opened, synchronize, reopened, closed]
 
 # Cancels all previous workflow runs for pull requests that have not completed.
 concurrency:
@@ -18,12 +19,7 @@ jobs:
     build:
         name: Create Demo and Attachments
         runs-on: ubuntu-latest
-        if: |
-            always() && (
-              github.event_name == 'pull_request' ||
-              github.event_name == 'workflow_dispatch' ||
-              github.repository == 'blockeraai/blockera'
-            )
+        if: github.event.action != 'closed'
 
         steps:
             - name: Checkout code
@@ -60,10 +56,10 @@ jobs:
                   set -euo pipefail
 
                   RELEASE_TAG="ci-artifacts"
-                  ARTIFACTS_TO_KEEP=2
                   SHORT_SHA="${SHORT_SHA:0:7}"
-                  ASSET_NAME="blockera-pr-${PR_NUMBER}-${SHORT_SHA}.zip"
-                  PUBLIC_URL="https://github.com/${REPO}/releases/download/${RELEASE_TAG}/${ASSET_NAME}"
+                  ASSET_NAME="blockera-pr-${PR_NUMBER}.zip"
+                  # Stable asset path; query string busts CDN/browser cache after each push.
+                  PUBLIC_URL="https://github.com/${REPO}/releases/download/${RELEASE_TAG}/${ASSET_NAME}?v=${SHORT_SHA}"
 
                   cp blockera.zip "${ASSET_NAME}"
 
@@ -76,29 +72,26 @@ jobs:
                       --prerelease
                   fi
 
-                  # Upload (replace if this exact asset name already exists from a rerun).
+                  # Overwrite the single zip for this PR.
                   gh release upload "${RELEASE_TAG}" "${ASSET_NAME}" \
                     --repo "${REPO}" \
                     --clobber
 
-                  # Prune older assets for this PR; keep the newest ARTIFACTS_TO_KEEP commit sets.
-                  PREFIX="blockera-pr-${PR_NUMBER}-"
-                  mapfile -t OLD_ASSETS < <(
+                  # Remove legacy sha-suffixed assets for this PR (blockera-pr-{N}-{sha}.zip).
+                  LEGACY_PREFIX="blockera-pr-${PR_NUMBER}-"
+                  mapfile -t LEGACY_ASSETS < <(
                     gh release view "${RELEASE_TAG}" --repo "${REPO}" --json assets \
-                      | jq -r --arg prefix "${PREFIX}" --argjson keep "${ARTIFACTS_TO_KEEP}" '
+                      | jq -r --arg prefix "${LEGACY_PREFIX}" '
                           .assets
                           | map(select(.name | startswith($prefix)))
-                          | sort_by(.createdAt)
-                          | reverse
-                          | .[$keep:]
                           | .[].name
                         '
                   )
 
-                  if ((${#OLD_ASSETS[@]} > 0)); then
-                    for old_asset in "${OLD_ASSETS[@]}"; do
-                      echo "Deleting old release asset: ${old_asset}"
-                      gh release delete-asset "${RELEASE_TAG}" "${old_asset}" --repo "${REPO}" --yes
+                  if ((${#LEGACY_ASSETS[@]} > 0)); then
+                    for legacy_asset in "${LEGACY_ASSETS[@]}"; do
+                      echo "Deleting legacy release asset: ${legacy_asset}"
+                      gh release delete-asset "${RELEASE_TAG}" "${legacy_asset}" --repo "${REPO}" --yes
                     done
                   fi
 
@@ -202,3 +195,44 @@ jobs:
                         $COMMENT_URL \
                         -d "{\"body\":\"${COMMENT_BODY}\"}"
                   fi
+
+    cleanup:
+        name: Remove PR CI Artifact
+        runs-on: ubuntu-latest
+        if: github.event.action == 'closed'
+        steps:
+            - name: Delete PR zip from ci-artifacts prerelease
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  PR_NUMBER: ${{ github.event.pull_request.number }}
+                  REPO: ${{ github.repository }}
+              run: |
+                  set -euo pipefail
+
+                  RELEASE_TAG="ci-artifacts"
+                  ASSET_NAME="blockera-pr-${PR_NUMBER}.zip"
+                  LEGACY_PREFIX="blockera-pr-${PR_NUMBER}-"
+
+                  if ! gh release view "${RELEASE_TAG}" --repo "${REPO}" >/dev/null 2>&1; then
+                    echo "Release ${RELEASE_TAG} not found; nothing to clean up."
+                    exit 0
+                  fi
+
+                  mapfile -t ASSETS_TO_DELETE < <(
+                    gh release view "${RELEASE_TAG}" --repo "${REPO}" --json assets \
+                      | jq -r --arg exact "${ASSET_NAME}" --arg prefix "${LEGACY_PREFIX}" '
+                          .assets
+                          | map(select(.name == $exact or (.name | startswith($prefix))))
+                          | .[].name
+                        '
+                  )
+
+                  if ((${#ASSETS_TO_DELETE[@]} == 0)); then
+                    echo "No release assets found for PR ${PR_NUMBER}."
+                    exit 0
+                  fi
+
+                  for asset in "${ASSETS_TO_DELETE[@]}"; do
+                    echo "Deleting release asset: ${asset}"
+                    gh release delete-asset "${RELEASE_TAG}" "${asset}" --repo "${REPO}" --yes || true
+                  done

--- a/.github/workflows/create-demo-attachments.yml
+++ b/.github/workflows/create-demo-attachments.yml
@@ -154,7 +154,8 @@ jobs:
                   BASE64_ENCODED_JSON=$(echo "$ENCODED_JSON" | base64 -w 0)
 
                   # Generate the final URL with encoded JSON appended
-                  DEMO_URL="https://playground.wordpress.net/#${BASE64_ENCODED_JSON}"
+                  # storage=temp + can-save=no: fresh site each open; no OPFS autosave restore.
+                  DEMO_URL="https://playground.wordpress.net/?storage=temp&can-save=no#${BASE64_ENCODED_JSON}"
 
                   # Save the URL as an output for later steps if needed
                   echo "demo_url=$DEMO_URL" >> $GITHUB_ENV

--- a/.github/workflows/create-demo-attachments.yml
+++ b/.github/workflows/create-demo-attachments.yml
@@ -10,6 +10,10 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
     cancel-in-progress: true
 
+permissions:
+    contents: write
+    pull-requests: read
+
 jobs:
     build:
         name: Create Demo and Attachments
@@ -38,18 +42,68 @@ jobs:
               with:
                   main-file-suffix: '-${{ github.event.pull_request.number }}'
 
-            - name: Upload ZIP to FTP server
-              uses: nerdoza/action-simple-file-upload@v2
+            - name: Upload ZIP as Actions artifact
+              uses: actions/upload-artifact@v4
               with:
-                  host: ${{ secrets.FTP_HOST }}
-                  user: ${{ secrets.FTP_USERNAME }}
-                  password: ${{ secrets.FTP_PASSWORD }}
-                  src: blockera.zip
-                  dest: /domains/cd.blockera.ai/public_html/blockera-${{ github.event.pull_request.number }}.zip
+                  name: blockera-pr-${{ github.event.pull_request.number }}
+                  path: blockera.zip
+                  retention-days: 14
+                  if-no-files-found: error
 
-            - name: Echo uploaded file link
+            - name: Publish ZIP to ci-artifacts prerelease
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  PR_NUMBER: ${{ github.event.pull_request.number }}
+                  REPO: ${{ github.repository }}
+                  SHORT_SHA: ${{ github.event.pull_request.head.sha }}
               run: |
-                  echo "uploaded_zip_file=https://${{ secrets.FTP_HOST }}/blockera-${{ github.event.pull_request.number }}.zip" >> $GITHUB_ENV
+                  set -euo pipefail
+
+                  RELEASE_TAG="ci-artifacts"
+                  ARTIFACTS_TO_KEEP=2
+                  SHORT_SHA="${SHORT_SHA:0:7}"
+                  ASSET_NAME="blockera-pr-${PR_NUMBER}-${SHORT_SHA}.zip"
+                  PUBLIC_URL="https://github.com/${REPO}/releases/download/${RELEASE_TAG}/${ASSET_NAME}"
+
+                  cp blockera.zip "${ASSET_NAME}"
+
+                  # Ensure a public prerelease exists (draft assets require auth and break Playground).
+                  if ! gh release view "${RELEASE_TAG}" --repo "${REPO}" >/dev/null 2>&1; then
+                    gh release create "${RELEASE_TAG}" \
+                      --repo "${REPO}" \
+                      --title "CI Artifacts" \
+                      --notes "Public PR build zips for WordPress Playground demos. Not a product release." \
+                      --prerelease
+                  fi
+
+                  # Upload (replace if this exact asset name already exists from a rerun).
+                  gh release upload "${RELEASE_TAG}" "${ASSET_NAME}" \
+                    --repo "${REPO}" \
+                    --clobber
+
+                  # Prune older assets for this PR; keep the newest ARTIFACTS_TO_KEEP commit sets.
+                  PREFIX="blockera-pr-${PR_NUMBER}-"
+                  mapfile -t OLD_ASSETS < <(
+                    gh release view "${RELEASE_TAG}" --repo "${REPO}" --json assets \
+                      | jq -r --arg prefix "${PREFIX}" --argjson keep "${ARTIFACTS_TO_KEEP}" '
+                          .assets
+                          | map(select(.name | startswith($prefix)))
+                          | sort_by(.createdAt)
+                          | reverse
+                          | .[$keep:]
+                          | .[].name
+                        '
+                  )
+
+                  if ((${#OLD_ASSETS[@]} > 0)); then
+                    for old_asset in "${OLD_ASSETS[@]}"; do
+                      echo "Deleting old release asset: ${old_asset}"
+                      gh release delete-asset "${RELEASE_TAG}" "${old_asset}" --repo "${REPO}" --yes
+                    done
+                  fi
+
+                  echo "uploaded_zip_file=${PUBLIC_URL}" >> "$GITHUB_ENV"
+                  echo "Public zip URL: ${PUBLIC_URL}"
 
             - name: Find existing bot comment
               id: find_comment
@@ -98,7 +152,7 @@ jobs:
                   fi
 
                   # Replace URL_PLACEMENT with the newly generated URL
-                  ENCODED_JSON=$(echo "$FINAL_JSON" | jq --arg new_url "${{ env.uploaded_zip_file }}" '.steps[2].pluginData.url = "${{ env.uploaded_zip_file }}"')
+                  ENCODED_JSON=$(echo "$FINAL_JSON" | jq --arg new_url "${{ env.uploaded_zip_file }}" '.steps[2].pluginData.url = $new_url')
 
                   # Update the blogname to append PR number
                   ENCODED_JSON=$(echo "$ENCODED_JSON" | jq --arg pr_num "${{ github.event.pull_request.number }}" '.steps[3].options.blogname += " (PR \($pr_num))"')

--- a/.github/workflows/create-demo-attachments.yml
+++ b/.github/workflows/create-demo-attachments.yml
@@ -150,6 +150,20 @@ jobs:
                   # Update the blogname to append PR number
                   ENCODED_JSON=$(echo "$ENCODED_JSON" | jq --arg pr_num "${{ github.event.pull_request.number }}" '.steps[3].options.blogname += " (PR \($pr_num))"')
 
+                  # Unique per workflow run so the blueprint hash / Playground setup fingerprint changes.
+                  ENCODED_JSON=$(echo "$ENCODED_JSON" | jq \
+                    --arg run_id "${{ github.run_id }}-${{ github.run_attempt }}" \
+                    '
+                      .meta.title = ((.meta.title // "Blockera Demo") + " [" + $run_id + "]")
+                      | .steps |= map(
+                          if .step == "defineWpConfigConsts" then
+                            .consts.BLOCKERA_PLAYGROUND_RUN_ID = $run_id
+                          else
+                            .
+                          end
+                        )
+                    ')
+
                   # Base64 encode the updated JSON
                   BASE64_ENCODED_JSON=$(echo "$ENCODED_JSON" | base64 -w 0)
 

--- a/.github/workflows/create-demo-attachments.yml
+++ b/.github/workflows/create-demo-attachments.yml
@@ -174,7 +174,7 @@ jobs:
                   RUN_ID="${{ github.run_id }}"
 
                   # Define the comment body following the desired structure
-                  COMMENT_BODY="**Branch Links**\n\n- [**🔗 Playground Demo**](${{ env.demo_url }})\n\n- [**📦 Download Zip** (Build)](${{ env.uploaded_zip_file }})"
+                  COMMENT_BODY="# 📈 PR Playground Demo\n\n**Branch Links**\n\n- [**🔗 Playground Demo**](${{ env.demo_url }})\n\n- [**📦 Download Zip** (Build)](${{ env.uploaded_zip_file }})"
 
                   if [ -z "${{ env.comment_id }}" ]; then
                       # No existing comment found, create a new one


### PR DESCRIPTION
## Summary
- Replace FTP hosting for PR Playground demo builds with a GitHub Actions artifact plus a public `ci-artifacts` prerelease asset.
- Keep the existing blockerabot “Branch Links” comment and `.github-playground.json` / `.pr-github-playground.json` merge.
- Prune older release assets per PR (keep last 2) so the shared prerelease does not grow unbounded.

## Why
WordPress Playground needs a public, unauthenticated zip URL. Actions artifacts alone are private, so the zip is also published on a `ci-artifacts` prerelease (not draft). This removes the FTP dependency and secrets.

## Test plan
- [x] Open/update a PR and confirm `Create Demo and Attachment Files` succeeds without FTP
- [x] Confirm the workflow run has artifact `blockera-pr-{N}`
- [x] Confirm the `ci-artifacts` prerelease has `blockera-pr-{N}-{shortsha}.zip`
- [x] Unauthenticated download of the release asset URL returns 200
- [x] Playground Demo link installs/activates Blockera
- [x] “Download Zip” in the blockerabot comment works
- [x] Push a second commit and confirm older assets for that PR are pruned (last 2 kept)

## Follow-up
- Remove unused `FTP_HOST` / `FTP_USERNAME` / `FTP_PASSWORD` secrets from the repo settings after merge