### PR TITLE
Autoload - respect production runtime when filtering dev dependencies

### DIFF
--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -126,6 +126,7 @@ status "Generating inc/app.php 📝"
 mkdir -p "inc"
 cp packages/blockera/php/app.php inc/app.php
 cp packages/autoloader-coordinator/class-shared-autoload-coordinator.php inc/class-shared-autoload-coordinator.php
+cp packages/autoloader-coordinator/bootstrap.php inc/bootstrap.php
 
 build_files=$(
 	ls dist/*/*.{min.js,min.css,asset.php} \

--- a/bin/generate-blockera-php.php
+++ b/bin/generate-blockera-php.php
@@ -65,13 +65,14 @@ while (true) {
 		case '### BEGIN AUTO-GENERATED AUTOLOADER':
 			$inside_defines = true;
 			echo $line;
-			echo "require_once __DIR__ . '/inc/class-shared-autoload-coordinator.php';
-\Blockera\SharedAutoload\Coordinator::getInstance()->registerPlugin('blockera', __DIR__);
-\Blockera\SharedAutoload\Coordinator::getInstance()->bootstrap();
+			echo <<<'PHP'
+require_once __DIR__ . '/inc/bootstrap.php';
+blockera_bootstrap_shared_autoloader('blockera', __DIR__, 10, ! defined('BLOCKERA_SB_FILE') || BLOCKERA_SB_FILE === __FILE__);
 
-// loading autoloader.
+// Fallback Composer autoloader for non-Blockera vendor packages.
 require __DIR__ . '/vendor/autoload.php';
-";
+
+PHP;
 			break;
 
 		case '### END AUTO-GENERATED AUTOLOADER':

--- a/bin/generate-blockera-php.php
+++ b/bin/generate-blockera-php.php
@@ -69,9 +69,6 @@ while (true) {
 require_once __DIR__ . '/inc/bootstrap.php';
 blockera_bootstrap_shared_autoloader('blockera', __DIR__, 10, ! defined('BLOCKERA_SB_FILE') || BLOCKERA_SB_FILE === __FILE__);
 
-// Fallback Composer autoloader for non-Blockera vendor packages.
-require __DIR__ . '/vendor/autoload.php';
-
 PHP;
 			break;
 

--- a/blockera.php
+++ b/blockera.php
@@ -24,37 +24,8 @@ if (! defined('ABSPATH')) {
 }
 
 ### BEGIN AUTO-GENERATED AUTOLOADER
-// the fallback way to load the composer default autoloader.
-if (! is_plugin_active('blockera-pro/blockera-pro.php')) {
-	require_once __DIR__ . '/vendor/autoload.php';
-} else {
-	// the shared autoloader way to load the composer customized autoloader.
-	add_filter(
-        'blockera/autoloader-coordinator/plugins/dependencies',
-        function ( array $plugins): array {
-			$plugins['blockera'] = [
-				'dir' => __DIR__,
-				'priority' => 10,
-				'default' => true,
-			];
-
-			return $plugins;
-		}
-    );
-
-	// Register into shared autoload coordinator.
-	// This replaces vendor/autoload.php by loading directly from Composer-generated static files.
-	require_once __DIR__ . '/packages/autoloader-coordinator/loader.php';
-
-	// Register into shared autoload coordinator and bootstrap autoloading.
-	\Blockera\SharedAutoload\Coordinator::getInstance()->registerPlugin();
-	\Blockera\SharedAutoload\Coordinator::getInstance()->bootstrap();
-
-	// Invalidate package manifest cache on plugin activation, deactivation, and upgrade.
-	add_action('activated_plugin', [ \Blockera\SharedAutoload\Coordinator::getInstance(), 'invalidatePackageManifest' ]);
-	add_action('deactivated_plugin', [ \Blockera\SharedAutoload\Coordinator::getInstance(), 'invalidatePackageManifest' ]);
-	add_action('upgrader_process_complete', [ \Blockera\SharedAutoload\Coordinator::getInstance(), 'invalidatePackageManifest' ]);
-}
+require_once __DIR__ . '/packages/autoloader-coordinator/bootstrap.php';
+blockera_bootstrap_shared_autoloader('blockera', __DIR__, 10, ! defined('BLOCKERA_SB_FILE') || BLOCKERA_SB_FILE === __FILE__);
 ### END AUTO-GENERATED AUTOLOADER
 
 if (file_exists(__DIR__ . '/.env')) {
@@ -141,8 +112,10 @@ $blockera_block_supports = apply_filters(
 	blockera_get_available_block_supports()
 );
 
-// Initialize hooks on Front Controller.
-blockera_load('bootstrap.hooks', __DIR__);
+// Initialize hooks on Front Controller when this product owns the bootstrap.
+if ( BLOCKERA_SB_FILE === __FILE__ ) {
+	blockera_load('bootstrap.hooks', __DIR__);
+}
 
 add_action('init', 'blockera_init', 10);
 

--- a/bootstrap/hooks.php
+++ b/bootstrap/hooks.php
@@ -9,6 +9,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+if ( defined( 'BLOCKERA_BOOTSTRAP_HOOKS_LOADED' ) ) {
+	return;
+}
+
+define( 'BLOCKERA_BOOTSTRAP_HOOKS_LOADED', true );
+
 use Blockera\WordPress\RenderBlock\Setup;
 use Blockera\Setup\Compatibility\BlockSupports\BlockeraDuotone;
 

--- a/packages/autoloader-coordinator/bootstrap.php
+++ b/packages/autoloader-coordinator/bootstrap.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Bootstrap the shared Blockera autoload coordinator.
+ *
+ * @package blockera/autoloader-coordinator
+ */
+
+if (! function_exists('blockera_bootstrap_shared_autoloader')) {
+	/**
+	 * Register a Blockera product with the shared autoload coordinator.
+	 *
+	 * @param string $slug     Product slug (e.g. blockera, blockera-one).
+	 * @param string $dir      Product root directory.
+	 * @param int    $priority Coordinator priority.
+	 * @param bool   $default  Whether this product is the default coordinator reference.
+	 */
+	function blockera_bootstrap_shared_autoloader( string $slug, string $dir, int $priority = 10, bool $default = false): void {
+		add_filter(
+			'blockera/autoloader-coordinator/plugins/dependencies',
+			static function ( array $repos ) use ( $slug, $dir, $priority, $default ): array {
+				$repos[ $slug ] = [
+					'dir'      => $dir,
+					'priority' => $priority,
+					'default'  => $default,
+				];
+
+				return $repos;
+			}
+		);
+
+		require_once __DIR__ . '/class-shared-autoload-coordinator.php';
+
+		$coordinator = \Blockera\SharedAutoload\Coordinator::getInstance();
+		$coordinator->registerPlugin();
+		$coordinator->bootstrap();
+
+		add_action('activated_plugin', [ $coordinator, 'invalidatePackageManifest' ]);
+		add_action('deactivated_plugin', [ $coordinator, 'invalidatePackageManifest' ]);
+		add_action('upgrader_process_complete', [ $coordinator, 'invalidatePackageManifest' ]);
+	}
+}

--- a/packages/autoloader-coordinator/bootstrap.php
+++ b/packages/autoloader-coordinator/bootstrap.php
@@ -5,6 +5,10 @@
  * @package blockera/autoloader-coordinator
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 if (! function_exists('blockera_bootstrap_shared_autoloader')) {
 	/**
 	 * Register a Blockera product with the shared autoload coordinator.

--- a/packages/autoloader-coordinator/class-shared-autoload-coordinator.php
+++ b/packages/autoloader-coordinator/class-shared-autoload-coordinator.php
@@ -36,6 +36,9 @@ if (! \class_exists(Coordinator::class)) {
 		/** @var bool */
 		private bool $autoloader_registered = false;
 
+		/** @var bool */
+		private bool $native_composer_bootstrapped = false;
+
 		/**
 		 * Combined ClassLoader instance for all plugins.
          *
@@ -232,15 +235,19 @@ if (! \class_exists(Coordinator::class)) {
 				);
 			}
 
-			$this->registerAutoloader();
-
-			if (2 <= $plugin_count && $this->bootstrapped) {
-				$this->maybeCoordinate();
+			if ($this->canUseNativeComposerAutoload()) {
+				$this->bootstrapNativeComposerAutoload();
 			} else {
-				$this->ensureAutoloadManifestIsBuilt();
+				$this->registerAutoloader();
 
-				if (! $this->shouldDeferFileInclusionUntilCompanionRegisters()) {
-					$this->includeAutoloadFiles();
+				if (2 <= $plugin_count && $this->bootstrapped) {
+					$this->maybeCoordinate();
+				} else {
+					$this->ensureAutoloadManifestIsBuilt();
+
+					if (! $this->shouldDeferFileInclusionUntilCompanionRegisters()) {
+						$this->includeAutoloadFiles();
+					}
 				}
 			}
 
@@ -248,6 +255,67 @@ if (! \class_exists(Coordinator::class)) {
 				$callback();
 			}
         }
+
+		/**
+		 * Whether the native Composer autoloader can replace manual bootstrap.
+		 * Single-product installs with matching Composer metadata use vendor/autoload.php
+		 * (same path as pre-coordinator Blockera) with near-zero coordinator overhead.
+		 */
+		private function canUseNativeComposerAutoload(): bool {
+			if (1 !== count($this->plugins)) {
+				return false;
+			}
+
+			if ($this->shouldDeferFileInclusionUntilCompanionRegisters()) {
+				return false;
+			}
+
+			$plugin = reset($this->plugins);
+
+			if (! is_array($plugin) || ! is_file($plugin['vendor_dir'] . '/autoload.php')) {
+				return false;
+			}
+
+			$context = $this->getInstalledPackagesContext($plugin['vendor_dir']);
+
+			// Production install (`composer install --no-dev`): Composer autoload matches runtime.
+			if (null === $context || empty($context['include_dev'])) {
+				return true;
+			}
+
+			// Dev install: native autoload only when dev runtime explicitly allows dev deps.
+			return $this->isBlockeraDevelopmentRuntime();
+		}
+
+		/**
+		 * Bootstrap via Composer's optimized vendor/autoload.php (single-plugin fast path).
+		 */
+		private function bootstrapNativeComposerAutoload(): void {
+			if ($this->native_composer_bootstrapped) {
+				return;
+			}
+
+			$plugin = reset($this->plugins);
+
+			require_once $plugin['vendor_dir'] . '/autoload.php';
+
+			$this->native_composer_bootstrapped = true;
+			$this->bootstrapped                 = true;
+			$this->autoloader_registered        = true;
+		}
+
+		/**
+		 * Whether autoload entries need per-path dev/runtime filtering.
+		 *
+		 * @param array $policy Autoload policy.
+		 */
+		private function shouldFilterAutoloadPaths( array $policy): bool {
+			if (! empty($policy['skip_vendor_dev_filter'])) {
+				return ! empty($policy['runtime_excluded_files']) || ! empty($policy['runtime_excluded_dirs']);
+			}
+
+			return true;
+		}
 
 		/**
 		 * Register the autoloader immediately.
@@ -374,7 +442,15 @@ if (! \class_exists(Coordinator::class)) {
 			$allowedPackages = null;
 			$devDirPrefixes  = [];
 			$devExactPaths   = [];
-			$runtimeExcluded = $this->getRootAutoloadDevPathRules($pluginDir);
+			$runtimeExcluded = [
+				'files' => [],
+				'dirs'  => [],
+			];
+
+			// Root autoload-dev paths are only relevant when dev packages remain in vendor metadata.
+			if ($composerIncludesDev && ! $includeDev) {
+				$runtimeExcluded = $this->getRootAutoloadDevPathRules($pluginDir);
+			}
 
 			if (null !== $context) {
 				if ($includeDev) {
@@ -643,6 +719,10 @@ if (! \class_exists(Coordinator::class)) {
 		 * @return array<string,string>
 		 */
 		private function filterDevAutoloadClassmapForPolicy( array $classmap, array $policy): array {
+			if (! $this->shouldFilterAutoloadPaths($policy)) {
+				return $classmap;
+			}
+
 			$filtered = [];
 
 			foreach ($classmap as $className => $filePath) {
@@ -664,6 +744,10 @@ if (! \class_exists(Coordinator::class)) {
 		 * @return array<string,string>
 		 */
 		private function filterDevAutoloadFilesForPolicy( array $files, array $policy): array {
+			if (! $this->shouldFilterAutoloadPaths($policy)) {
+				return $files;
+			}
+
 			$filtered = [];
 
 			foreach ($files as $identifier => $filePath) {
@@ -729,10 +813,11 @@ if (! \class_exists(Coordinator::class)) {
 				return;
 			}
 
-			$vendorDir   = $plugin['vendor_dir'];
-			$pluginDir   = $plugin['plugin_dir'];
-			$composerDir = $vendorDir . '/composer';
-			$policy      = $this->getAutoloadPolicy($vendorDir, $pluginDir);
+			$vendorDir    = $plugin['vendor_dir'];
+			$pluginDir    = $plugin['plugin_dir'];
+			$composerDir  = $vendorDir . '/composer';
+			$policy       = $this->getAutoloadPolicy($vendorDir, $pluginDir);
+			$filter_paths = $this->shouldFilterAutoloadPaths($policy);
 
 			// Load PSR-4 mappings.
 			$psr4File = $composerDir . '/autoload_psr4.php';
@@ -744,12 +829,16 @@ if (! \class_exists(Coordinator::class)) {
 							continue;
 						}
 
-						foreach ($paths as $path) {
-							if ($this->shouldSkipAutoloadPath( (string) $path, $policy)) {
-								continue;
-							}
+						if ($filter_paths) {
+							foreach ($paths as $path) {
+								if ($this->shouldSkipAutoloadPath( (string) $path, $policy)) {
+									continue;
+								}
 
-							$this->class_loader->addPsr4($namespace, $path);
+								$this->class_loader->addPsr4($namespace, $path);
+							}
+						} else {
+							$this->class_loader->addPsr4($namespace, $paths);
 						}
 					}
 				}
@@ -788,12 +877,16 @@ if (! \class_exists(Coordinator::class)) {
 
 				if ($needs_vendor_psr4 && ! empty($fallback['psr4'])) {
 					foreach ($fallback['psr4'] as $namespace => $paths) {
-						foreach ($paths as $path) {
-							if ($this->shouldSkipAutoloadPath( (string) $path, $policy)) {
-								continue;
-							}
+						if ($filter_paths) {
+							foreach ($paths as $path) {
+								if ($this->shouldSkipAutoloadPath( (string) $path, $policy)) {
+									continue;
+								}
 
-							$this->class_loader->addPsr4($namespace, $path);
+								$this->class_loader->addPsr4($namespace, $path);
+							}
+						} else {
+							$this->class_loader->addPsr4($namespace, $paths);
 						}
 					}
 				}
@@ -803,8 +896,8 @@ if (! \class_exists(Coordinator::class)) {
 				$this->autoload_manifest = [];
 			}
 			$this->autoload_manifest[ $slug ] = [
-				'files' => is_array($files) ? $this->filterDevAutoloadFilesForPolicy($files, $policy) : [],
-				'classmap' => is_array($classmap) ? $classmap : [],
+				'files'      => is_array($files) ? $files : [],
+				'classmap'   => is_array($classmap) ? $classmap : [],
 				'vendor_dir' => $vendorDir,
 			];
 		}
@@ -1353,6 +1446,11 @@ if (! \class_exists(Coordinator::class)) {
 				return;
 			}
 
+			if (1 === count($this->plugins) && 1 === count($this->autoload_manifest)) {
+				$this->includeAutoloadFilesForSinglePlugin();
+				return;
+			}
+
 			$allFiles        = $this->preparePackagesFiles();
 			$preferredPlugin = $this->getPreferredPluginSlug();
 			$package_groups  = $this->partitionExclusiveAndSharedPackages($allFiles);
@@ -1371,6 +1469,21 @@ if (! \class_exists(Coordinator::class)) {
 				foreach ($this->selectWinningAutoloadFiles($packageName, $files, $preferredPlugin) as $file) {
 					$this->includeFile($file['identifier'], $file['path']);
 				}
+			}
+		}
+
+		/**
+		 * Include autoload files for a single registered plugin without package coordination.
+		 */
+		private function includeAutoloadFilesForSinglePlugin(): void {
+			$manifest = reset($this->autoload_manifest);
+
+			if (! is_array($manifest) || ! isset($manifest['files']) || ! is_array($manifest['files'])) {
+				return;
+			}
+
+			foreach ($manifest['files'] as $identifier => $filePath) {
+				$this->includeFile( (string) $identifier, (string) $filePath);
 			}
 		}
 

--- a/packages/autoloader-coordinator/class-shared-autoload-coordinator.php
+++ b/packages/autoloader-coordinator/class-shared-autoload-coordinator.php
@@ -52,6 +52,13 @@ if (! \class_exists(Coordinator::class)) {
 		private array $included_files = [];
 
 		/**
+		 * Normalized autoload file paths already included (prevents duplicate requires).
+		 *
+		 * @var array<string,bool>
+		 */
+		private array $included_file_paths = [];
+
+		/**
 		 * Cached prepared package files for the current request.
 		 *
 		 * @var array<string,array<int,array{identifier:string,path:string,version:string,plugin:string}>>|null
@@ -89,7 +96,7 @@ if (! \class_exists(Coordinator::class)) {
 		/**
 		 * Cached autoload policy per vendor/plugin pair (computed once per request).
 		 *
-		 * @var array<string,array{include_dev:bool,skip_vendor_dev_filter:bool,allowed_packages:?array<string,bool>,dev_dir_prefixes:array<int,string>,dev_exact_paths:array<string,bool>}>
+		 * @var array<string,array{include_dev:bool,skip_vendor_dev_filter:bool,allowed_packages:?array<string,bool>,dev_dir_prefixes:array<int,string>,dev_exact_paths:array<string,bool>,runtime_excluded_files:array<string,bool>,runtime_excluded_dirs:array<int,string>}>
 		 */
 		private array $autoload_policy_by_key = [];
 
@@ -313,14 +320,45 @@ if (! \class_exists(Coordinator::class)) {
 		}
 
 		/**
+		 * Whether Blockera is running in an explicit development runtime.
+		 * Defaults to production-safe behavior during WordPress bootstrap.
+		 */
+		private function isBlockeraDevelopmentRuntime(): bool {
+			if (defined('BLOCKERA_SB_MODE') && 'production' === BLOCKERA_SB_MODE) {
+				return false;
+			}
+
+			if (defined('BLOCKERA_PRO_APP_MODE') && 'production' === BLOCKERA_PRO_APP_MODE) {
+				return false;
+			}
+
+			$app_mode = $_ENV['APP_MODE'] ?? $_SERVER['APP_MODE'] ?? getenv('APP_MODE');
+
+			if (is_string($app_mode) && 'development' === $app_mode) {
+				return true;
+			}
+
+			if (defined('BLOCKERA_SB_MODE') && 'development' === BLOCKERA_SB_MODE) {
+				return true;
+			}
+
+			if (defined('BLOCKERA_PRO_APP_MODE') && 'development' === BLOCKERA_PRO_APP_MODE) {
+				return true;
+			}
+
+			return false;
+		}
+
+		/**
 		 * Resolve autoload policy for a plugin vendor tree (computed once, cached per request).
 		 *
 		 * Production installs (`composer install --no-dev`) already omit dev autoload entries
-		 * from vendor/composer/autoload_*.php, so we skip per-path filtering on that hot path.
+		 * from vendor/composer/autoload_*.php. When Composer was installed with dev dependencies
+		 * but Blockera is running in production mode, dev paths are filtered at runtime.
 		 *
 		 * @param string $vendorDir Vendor directory path.
 		 * @param string $pluginDir Plugin root directory path.
-		 * @return array{include_dev:bool,skip_vendor_dev_filter:bool,allowed_packages:?array<string,bool>,dev_dir_prefixes:array<int,string>,dev_exact_paths:array<string,bool>}
+		 * @return array{include_dev:bool,skip_vendor_dev_filter:bool,allowed_packages:?array<string,bool>,dev_dir_prefixes:array<int,string>,dev_exact_paths:array<string,bool>,runtime_excluded_files:array<string,bool>,runtime_excluded_dirs:array<int,string>}
 		 */
 		private function getAutoloadPolicy( string $vendorDir, string $pluginDir): array {
 			$cacheKey = $this->getAutoloadPolicyCacheKey($vendorDir, $pluginDir);
@@ -329,12 +367,14 @@ if (! \class_exists(Coordinator::class)) {
 				return $this->autoload_policy_by_key[ $cacheKey ];
 			}
 
-			$context    = $this->getInstalledPackagesContext($vendorDir);
-			$includeDev = $context['include_dev'] ?? false;
+			$context             = $this->getInstalledPackagesContext($vendorDir);
+			$composerIncludesDev = $context['include_dev'] ?? false;
+			$includeDev          = $composerIncludesDev && $this->isBlockeraDevelopmentRuntime();
 
 			$allowedPackages = null;
 			$devDirPrefixes  = [];
 			$devExactPaths   = [];
+			$runtimeExcluded = $this->getRootAutoloadDevPathRules($pluginDir);
 
 			if (null !== $context) {
 				if ($includeDev) {
@@ -356,23 +396,17 @@ if (! \class_exists(Coordinator::class)) {
 
 						$devDirPrefixes[] = $prefix . '/';
 					}
-
-					$rootDevRules = $this->getRootAutoloadDevPathRules($pluginDir);
-
-					foreach ($rootDevRules['dirs'] as $dirPrefix) {
-						$devDirPrefixes[] = $dirPrefix;
-					}
-
-					$devExactPaths = $rootDevRules['files'];
 				}
 			}
 
 			$policy = [
 				'include_dev'              => $includeDev,
-				'skip_vendor_dev_filter'   => ! $includeDev && is_file($vendorDir . '/composer/autoload_psr4.php'),
+				'skip_vendor_dev_filter'   => ! $composerIncludesDev && is_file($vendorDir . '/composer/autoload_psr4.php'),
 				'allowed_packages'         => $allowedPackages,
 				'dev_dir_prefixes'         => $devDirPrefixes,
 				'dev_exact_paths'          => $devExactPaths,
+				'runtime_excluded_files'   => $runtimeExcluded['files'],
+				'runtime_excluded_dirs'    => $runtimeExcluded['dirs'],
 			];
 
 			$this->autoload_policy_by_key[ $cacheKey ]              = $policy;
@@ -391,6 +425,16 @@ if (! \class_exists(Coordinator::class)) {
 				return $this->include_dev_dependencies_by_vendor[ $vendorDir ];
 			}
 
+			foreach ($this->plugins as $plugin) {
+				if ($plugin['vendor_dir'] !== $vendorDir) {
+					continue;
+				}
+
+				$policy = $this->getAutoloadPolicy($vendorDir, $plugin['plugin_dir']);
+
+				return $policy['include_dev'];
+			}
+
 			$context = $this->getInstalledPackagesContext($vendorDir);
 
 			if (null === $context) {
@@ -398,9 +442,11 @@ if (! \class_exists(Coordinator::class)) {
 				return false;
 			}
 
-			$this->include_dev_dependencies_by_vendor[ $vendorDir ] = $context['include_dev'];
+			$includeDev = $context['include_dev'] && $this->isBlockeraDevelopmentRuntime();
 
-			return $context['include_dev'];
+			$this->include_dev_dependencies_by_vendor[ $vendorDir ] = $includeDev;
+
+			return $includeDev;
 		}
 
 		/**
@@ -463,6 +509,8 @@ if (! \class_exists(Coordinator::class)) {
 
 		/**
 		 * Resolve root-project autoload-dev path rules from composer.json.
+		 * These paths are excluded from WordPress runtime autoloading in all modes.
+		 * PHPUnit bootstraps load them explicitly.
 		 *
 		 * @param string $pluginDir Plugin root directory path.
 		 * @return array{files:array<string,bool>,dirs:array<int,string>}
@@ -548,6 +596,46 @@ if (! \class_exists(Coordinator::class)) {
 		}
 
 		/**
+		 * Check whether an autoload path is excluded from WordPress runtime loading.
+		 *
+		 * @param string $path   File or directory path.
+		 * @param array  $policy Autoload policy.
+		 */
+		private function isRuntimeExcludedAutoloadPath( string $path, array $policy): bool {
+			$normalized = $this->normalizePath($path);
+
+			if (! empty($policy['runtime_excluded_files'][ $normalized ])) {
+				return true;
+			}
+
+			foreach ($policy['runtime_excluded_dirs'] ?? [] as $prefix) {
+				if (rtrim($prefix, '/\\') === $normalized || 0 === strpos($normalized, $prefix)) {
+					return true;
+				}
+			}
+
+			return false;
+		}
+
+		/**
+		 * Decide whether an autoload path should be skipped for the current request.
+		 *
+		 * @param string $path   File or directory path.
+		 * @param array  $policy Autoload policy.
+		 */
+		private function shouldSkipAutoloadPath( string $path, array $policy): bool {
+			if ($this->isRuntimeExcludedAutoloadPath($path, $policy)) {
+				return true;
+			}
+
+			if (! empty($policy['skip_vendor_dev_filter'])) {
+				return false;
+			}
+
+			return $this->isDevAutoloadPathForPolicy($path, $policy);
+		}
+
+		/**
 		 * Remove dev dependency entries from a Composer classmap.
 		 *
 		 * @param array<string,string> $classmap Composer classmap.
@@ -555,14 +643,10 @@ if (! \class_exists(Coordinator::class)) {
 		 * @return array<string,string>
 		 */
 		private function filterDevAutoloadClassmapForPolicy( array $classmap, array $policy): array {
-			if (empty($policy['dev_dir_prefixes']) && empty($policy['dev_exact_paths'])) {
-				return $classmap;
-			}
-
 			$filtered = [];
 
 			foreach ($classmap as $className => $filePath) {
-				if ($this->isDevAutoloadPathForPolicy( (string) $filePath, $policy)) {
+				if ($this->shouldSkipAutoloadPath( (string) $filePath, $policy)) {
 					continue;
 				}
 
@@ -580,14 +664,10 @@ if (! \class_exists(Coordinator::class)) {
 		 * @return array<string,string>
 		 */
 		private function filterDevAutoloadFilesForPolicy( array $files, array $policy): array {
-			if (empty($policy['dev_dir_prefixes']) && empty($policy['dev_exact_paths'])) {
-				return $files;
-			}
-
 			$filtered = [];
 
 			foreach ($files as $identifier => $filePath) {
-				if ($this->isDevAutoloadPathForPolicy( (string) $filePath, $policy)) {
+				if ($this->shouldSkipAutoloadPath( (string) $filePath, $policy)) {
 					continue;
 				}
 
@@ -595,51 +675,6 @@ if (! \class_exists(Coordinator::class)) {
 			}
 
 			return $filtered;
-		}
-
-		/**
-		 * Collect root-project autoload-dev metadata for package fallback mode.
-		 *
-		 * @param array{plugin_dir:string,vendor_dir:string,packages_dir:string} $plugin Plugin data.
-		 * @return array{files:array<string,string>,psr4:array<string,array<int,string>>}
-		 */
-		private function collectRootComposerAutoloadDev( array $plugin): array {
-			$result = [
-				'files' => [],
-				'psr4'  => [],
-			];
-
-			if (! $this->shouldIncludeDevDependencies($plugin['vendor_dir'])) {
-				return $result;
-			}
-
-			$composerJson = $plugin['plugin_dir'] . '/composer.json';
-
-			if (! is_file($composerJson)) {
-				return $result;
-			}
-
-			$json = @file_get_contents($composerJson);
-
-			if (false === $json) {
-				return $result;
-			}
-
-			$data = json_decode($json, true, 512, JSON_BIGINT_AS_STRING);
-
-			if (! is_array($data)) {
-				return $result;
-			}
-
-			$package_name = isset($data['name']) ? (string) $data['name'] : $composerJson;
-
-			return $this->appendComposerAutoloadSections(
-				$data['autoload-dev'] ?? [],
-				$plugin['plugin_dir'],
-				$package_name,
-				$result,
-				'autoload-dev'
-			);
 		}
 
 		/**
@@ -710,7 +745,7 @@ if (! \class_exists(Coordinator::class)) {
 						}
 
 						foreach ($paths as $path) {
-							if (! $policy['skip_vendor_dev_filter'] && $this->isDevAutoloadPathForPolicy( (string) $path, $policy)) {
+							if ($this->shouldSkipAutoloadPath( (string) $path, $policy)) {
 								continue;
 							}
 
@@ -726,10 +761,7 @@ if (! \class_exists(Coordinator::class)) {
 			if (is_file($classmapFile)) {
 				$classmap = $this->loadAutoloadFile($classmapFile, $vendorDir, dirname($vendorDir));
 				if (is_array($classmap)) {
-					if (! $policy['skip_vendor_dev_filter']) {
-						$classmap = $this->filterDevAutoloadClassmapForPolicy($classmap, $policy);
-					}
-
+					$classmap = $this->filterDevAutoloadClassmapForPolicy($classmap, $policy);
 					$this->class_loader->addClassMap($classmap);
 				}
 			}
@@ -739,18 +771,16 @@ if (! \class_exists(Coordinator::class)) {
 			$files     = null;
 			if (is_file($filesFile)) {
 				$files = $this->loadAutoloadFile($filesFile, $vendorDir, dirname($vendorDir));
-				if (is_array($files) && ! $policy['skip_vendor_dev_filter']) {
+				if (is_array($files)) {
 					$files = $this->filterDevAutoloadFilesForPolicy($files, $policy);
 				}
 			}
 
-			$needs_vendor_files    = ! is_array($files) || empty($files);
-			$needs_vendor_psr4     = ! is_file($psr4File);
-			$used_package_fallback = false;
+			$needs_vendor_files = ! is_array($files) || empty($files);
+			$needs_vendor_psr4  = ! is_file($psr4File);
 
 			if ($needs_vendor_files || $needs_vendor_psr4) {
-				$fallback              = $this->collectAutoloadFromPackages($plugin);
-				$used_package_fallback = true;
+				$fallback = $this->collectAutoloadFromPackages($plugin);
 
 				if ($needs_vendor_files && ! empty($fallback['files'])) {
 					$files = array_merge(is_array($files) ? $files : [], $fallback['files']);
@@ -759,22 +789,10 @@ if (! \class_exists(Coordinator::class)) {
 				if ($needs_vendor_psr4 && ! empty($fallback['psr4'])) {
 					foreach ($fallback['psr4'] as $namespace => $paths) {
 						foreach ($paths as $path) {
-							$this->class_loader->addPsr4($namespace, $path);
-						}
-					}
-				}
-			}
+							if ($this->shouldSkipAutoloadPath( (string) $path, $policy)) {
+								continue;
+							}
 
-			if ($used_package_fallback && $this->shouldIncludeDevDependencies($vendorDir)) {
-				$rootDevAutoload = $this->collectRootComposerAutoloadDev($plugin);
-
-				if (! empty($rootDevAutoload['files'])) {
-					$files = array_merge(is_array($files) ? $files : [], $rootDevAutoload['files']);
-				}
-
-				if (! empty($rootDevAutoload['psr4'])) {
-					foreach ($rootDevAutoload['psr4'] as $namespace => $paths) {
-						foreach ($paths as $path) {
 							$this->class_loader->addPsr4($namespace, $path);
 						}
 					}
@@ -785,7 +803,7 @@ if (! \class_exists(Coordinator::class)) {
 				$this->autoload_manifest = [];
 			}
 			$this->autoload_manifest[ $slug ] = [
-				'files' => is_array($files) ? $files : [],
+				'files' => is_array($files) ? $this->filterDevAutoloadFilesForPolicy($files, $policy) : [],
 				'classmap' => is_array($classmap) ? $classmap : [],
 				'vendor_dir' => $vendorDir,
 			];
@@ -1457,6 +1475,17 @@ if (! \class_exists(Coordinator::class)) {
 				}
 
 				foreach ($manifest['files'] as $identifier => $filePath) {
+					$pluginDir = $this->plugins[ $slug ]['plugin_dir'] ?? '';
+					$vendorDir = $manifest['vendor_dir'] ?? ( $this->plugins[ $slug ]['vendor_dir'] ?? '' );
+
+					if ('' !== $pluginDir && '' !== $vendorDir) {
+						$policy = $this->getAutoloadPolicy($vendorDir, $pluginDir);
+
+						if ($this->shouldSkipAutoloadPath( (string) $filePath, $policy)) {
+							continue;
+						}
+					}
+
 					// Detect package for this file.
 					$packageInfo = $this->detectPackageFromPath($filePath);
 					$packageName = $packageInfo['name'] ?? 'unknown-' . $identifier;
@@ -1498,11 +1527,30 @@ if (! \class_exists(Coordinator::class)) {
 				return;
 			}
 
-			if (is_file($file)) {
+			if (! is_file($file)) {
+				return;
+			}
+
+			$normalized = $this->normalizePath($file);
+
+			if (isset($this->included_file_paths[ $normalized ])) {
 				$this->included_files[ $identifier ]               = true;
 				$GLOBALS['blockera_autoload_files'][ $identifier ] = true;
-				require $file;
+				return;
 			}
+
+			if (isset($GLOBALS['blockera_autoload_file_paths'][ $normalized ])) {
+				$this->included_files[ $identifier ]               = true;
+				$this->included_file_paths[ $normalized ]          = true;
+				$GLOBALS['blockera_autoload_files'][ $identifier ] = true;
+				return;
+			}
+
+			$this->included_files[ $identifier ]                    = true;
+			$this->included_file_paths[ $normalized ]               = true;
+			$GLOBALS['blockera_autoload_files'][ $identifier ]      = true;
+			$GLOBALS['blockera_autoload_file_paths'][ $normalized ] = true;
+			require $file;
 		}
 
 		/**

--- a/packages/autoloader-coordinator/class-shared-autoload-coordinator.php
+++ b/packages/autoloader-coordinator/class-shared-autoload-coordinator.php
@@ -400,9 +400,21 @@ if (! \class_exists(Coordinator::class)) {
 				return false;
 			}
 
-			$app_mode = $_ENV['APP_MODE'] ?? $_SERVER['APP_MODE'] ?? getenv('APP_MODE');
+			$app_mode = null;
 
-			if (is_string($app_mode) && 'development' === $app_mode) {
+			if (isset($_ENV['APP_MODE'])) {
+				$app_mode = sanitize_text_field(wp_unslash($_ENV['APP_MODE']));
+			} elseif (isset($_SERVER['APP_MODE'])) {
+				$app_mode = sanitize_text_field(wp_unslash($_SERVER['APP_MODE']));
+			} else {
+				$env_value = getenv('APP_MODE');
+
+				if (false !== $env_value && is_string($env_value)) {
+					$app_mode = sanitize_text_field($env_value);
+				}
+			}
+
+			if (null !== $app_mode && 'development' === $app_mode) {
 				return true;
 			}
 

--- a/packages/autoloader-coordinator/loader.php
+++ b/packages/autoloader-coordinator/loader.php
@@ -1,5 +1,12 @@
 <?php
 /**
  * Autoloader coordinator loader.
+ *
+ * @package blockera/autoloader-coordinator
  */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 require_once __DIR__ . '/class-shared-autoload-coordinator.php';


### PR DESCRIPTION
Filter Composer dev autoload paths when the vendor tree includes dev packages
but Blockera runs in production mode, always exclude root autoload-dev files,
and dedupe included autoload files by normalized path.