### PR TITLE
Fix/header UI

### DIFF
--- a/packages/blockera-admin/js/components/panels/general-panel/index.js
+++ b/packages/blockera-admin/js/components/panels/general-panel/index.js
@@ -20,10 +20,7 @@ import {
 	ControlContextProvider,
 } from '@blockera/controls';
 import { Icon } from '@blockera/icons';
-import {
-	BreakpointsSettings,
-	getSortedBreakpoints,
-} from '@blockera/editor/js/editor/header-ui';
+import { BreakpointsSettings } from '@blockera/editor/js/editor/header-ui';
 import type { BreakpointTypes } from '@blockera/editor/js/extensions/libs/block-card/block-states/types';
 
 /**
@@ -92,12 +89,9 @@ export const GeneralPanel = (): MixedElement => {
 			});
 	};
 
-	// Memoize the sorted breakpoints to prevent re-creation on every render.
-	const sortedBreakpoints = useMemo(() => {
-		return getSortedBreakpoints(generalSettings.breakpoints, {
-			output: 'objects',
-		});
-	}, [generalSettings.breakpoints]);
+	// Breakpoints repeater manages row order internally via each item's `order` field.
+	// Avoid re-sorting here so parent echoes do not churn object references on delete.
+	const breakpointsForSettings = generalSettings.breakpoints;
 
 	// Memoize the default value to prevent re-creation.
 	const breakpointsDefaultValue = useMemo(() => {
@@ -105,20 +99,14 @@ export const GeneralPanel = (): MixedElement => {
 	}, [defaultSettings?.general?.breakpoints]);
 
 	const memoizedCallback = useCallback((newValue: Object) => {
-		newValue = getSortedBreakpoints(newValue, {
-			output: 'objects',
-		});
-
-		newValue = Object.fromEntries(
+		const normalizedValue = Object.fromEntries(
 			Object.entries((newValue: Object)).map(
 				([key, breakpoint]: [string, BreakpointTypes | Object]) => {
-					return [
-						key,
-						{
-							...breakpoint,
-							...('' === breakpoint.type ? { type: key } : {}),
-						},
-					];
+					if ('' === breakpoint.type) {
+						return [key, { ...breakpoint, type: key }];
+					}
+
+					return [key, breakpoint];
 				}
 			)
 		);
@@ -126,7 +114,10 @@ export const GeneralPanel = (): MixedElement => {
 			added: savedAdded,
 			deleted: savedDeleted,
 			updated: savedUpdated,
-		} = detailedDiff(window.blockeraSettings.general.breakpoints, newValue);
+		} = detailedDiff(
+			window.blockeraSettings.general.breakpoints,
+			normalizedValue
+		);
 
 		setHasUpdates(
 			Object.keys(savedAdded).length > 0 ||
@@ -138,7 +129,7 @@ export const GeneralPanel = (): MixedElement => {
 			...settings,
 			general: {
 				...generalSettings,
-				breakpoints: newValue,
+				breakpoints: normalizedValue,
 			},
 		});
 		// eslint-disable-next-line react-hooks/exhaustive-deps
@@ -184,7 +175,7 @@ export const GeneralPanel = (): MixedElement => {
 				>
 					<BreakpointsSettings
 						onChange={memoizedCallback}
-						breakpoints={sortedBreakpoints}
+						breakpoints={breakpointsForSettings}
 						defaultValue={breakpointsDefaultValue}
 					/>
 				</div>

--- a/packages/editor/js/editor/header-ui/components/breakpoints/breakpoint-settings/index.js
+++ b/packages/editor/js/editor/header-ui/components/breakpoints/breakpoint-settings/index.js
@@ -5,13 +5,13 @@
  */
 import { __ } from '@wordpress/i18n';
 import { applyFilters } from '@wordpress/hooks';
-import { useMemo, memo } from '@wordpress/element';
+import { useMemo, memo, useCallback, useRef } from '@wordpress/element';
 import type { MixedElement, ComponentType } from 'react';
 
 /**
  * Blockera dependencies
  */
-import { mergeObject } from '@blockera/utils';
+import { mergeObject, isEquals } from '@blockera/utils';
 import {
 	controlInnerClassNames,
 	controlClassNames,
@@ -61,6 +61,11 @@ const defaultRepeaterItemValue = {
 	attributes: {},
 };
 
+const filteredDefaultRepeaterItemValue = applyFilters(
+	'blockera.breakpoints.defaultRepeaterItemValue',
+	defaultRepeaterItemValue
+);
+
 const BreakpointsSettings: ComponentType<BreakpointSettingsComponentProps> =
 	memo(
 		({
@@ -68,8 +73,23 @@ const BreakpointsSettings: ComponentType<BreakpointSettingsComponentProps> =
 			breakpoints,
 			defaultValue,
 		}: BreakpointSettingsComponentProps): MixedElement => {
-			breakpoints = useMemo(() => {
-				return Object.fromEntries(
+			const customBreakpointIdRef = useRef(
+				Object.keys(breakpoints).reduce((maxId, key) => {
+					const match = /^custom-(\d+)$/.exec(key);
+
+					if (!match) {
+						return maxId;
+					}
+
+					return Math.max(maxId, parseInt(match[1], 10));
+				}, 0)
+			);
+			const stableContextRef = useRef(null);
+
+			const stableMergedRef = useRef(null);
+
+			const mergedBreakpoints = useMemo(() => {
+				const next = Object.fromEntries(
 					Object.entries(breakpoints).map(([key, value]) => [
 						key,
 						mergeObject(defaultRepeaterItemValue, {
@@ -79,18 +99,84 @@ const BreakpointsSettings: ComponentType<BreakpointSettingsComponentProps> =
 						}),
 					])
 				);
-				// eslint-disable-next-line react-hooks/exhaustive-deps
+				const previous = stableMergedRef.current;
+
+				if (previous && isEquals(previous, next)) {
+					return previous;
+				}
+
+				stableMergedRef.current = next;
+
+				return next;
 			}, [breakpoints]);
+
+			const controlContextValue = useMemo(() => {
+				const nextValue = applyFilters(
+					'blockera.breakpoints.value',
+					mergedBreakpoints
+				);
+				const previous = stableContextRef.current;
+
+				if (previous && isEquals(previous.value, nextValue)) {
+					return previous;
+				}
+
+				const next = {
+					name: 'canvas-editor-breakpoints',
+					value: nextValue,
+					// Keep the repeater store as the editing source of truth.
+					// Parent onChange echoes would otherwise re-sync and remount rows.
+					skipSyncValue: true,
+				};
+
+				stableContextRef.current = next;
+
+				return next;
+			}, [mergedBreakpoints]);
+
+			const valueCleanup = useCallback((value) => {
+				return Object.fromEntries(
+					Object.entries(value).map(([key, item]) => {
+						const cleanRepeaterItem = cleanupRepeaterItem(item);
+
+						if (!item.isDefault) {
+							return [
+								key,
+								{
+									...cleanRepeaterItem,
+									deletable: true,
+								},
+							];
+						}
+
+						return [
+							key,
+							{
+								...cleanRepeaterItem,
+								deletable: false,
+							},
+						];
+					})
+				);
+			}, []);
+
+			const itemIdGenerator = useCallback((): string => {
+				customBreakpointIdRef.current += 1;
+
+				return `custom-${customBreakpointIdRef.current}`;
+			}, []);
+
+			const popoverTitle = useCallback((itemId, item) => {
+				if (getBaseBreakpoint() === itemId) {
+					return item.label;
+				}
+
+				return __('Breakpoint Settings', 'blockera');
+			}, []);
 
 			return (
 				<ControlContextProvider
-					value={{
-						name: 'canvas-editor-breakpoints',
-						value: applyFilters(
-							'blockera.breakpoints.value',
-							breakpoints
-						),
-					}}
+					value={controlContextValue}
 					storeName={REPEATER_STORE_NAME}
 				>
 					<BaseControl
@@ -100,50 +186,18 @@ const BreakpointsSettings: ComponentType<BreakpointSettingsComponentProps> =
 						<RepeaterControl
 							id="breakpoints"
 							mode={'accordion'}
+							// Prop name is inverted in repeater reducers: false keeps stable
+							// slug keys (desktop, tablet, custom-N) when deleting rows.
 							disableRegenerateId={false}
-							popoverTitle={(itemId, item) => {
-								if (getBaseBreakpoint() === itemId) {
-									return item.label;
-								}
-
-								return __('Breakpoint Settings', 'blockera');
-							}}
-							valueCleanup={(value) => {
-								return Object.fromEntries(
-									Object.entries(value).map(([key, item]) => {
-										const cleanRepeaterItem =
-											cleanupRepeaterItem(item);
-
-										if (!item.isDefault) {
-											return [
-												key,
-												{
-													...cleanRepeaterItem,
-													deletable: true,
-												},
-											];
-										}
-
-										return [
-											key,
-											{
-												...cleanRepeaterItem,
-												deletable: false,
-											},
-										];
-									})
-								);
-							}}
-							itemIdGenerator={(itemsCount) => {
-								return `custom-${itemsCount}`;
-							}}
+							popoverTitle={popoverTitle}
+							valueCleanup={valueCleanup}
+							itemIdGenerator={itemIdGenerator}
 							className={controlInnerClassNames(
 								'breakpoints-repeater'
 							)}
-							defaultRepeaterItemValue={applyFilters(
-								'blockera.breakpoints.defaultRepeaterItemValue',
-								defaultRepeaterItemValue
-							)}
+							defaultRepeaterItemValue={
+								filteredDefaultRepeaterItemValue
+							}
 							repeaterItemHeader={Header}
 							repeaterItemChildren={Fields}
 							onChange={onChange}

--- a/packages/editor/js/editor/header-ui/components/breakpoints/breakpoint-settings/index.js
+++ b/packages/editor/js/editor/header-ui/components/breakpoints/breakpoint-settings/index.js
@@ -5,13 +5,13 @@
  */
 import { __ } from '@wordpress/i18n';
 import { applyFilters } from '@wordpress/hooks';
-import { useMemo, memo } from '@wordpress/element';
+import { useMemo, memo, useCallback, useRef } from '@wordpress/element';
 import type { MixedElement, ComponentType } from 'react';
 
 /**
  * Blockera dependencies
  */
-import { mergeObject } from '@blockera/utils';
+import { mergeObject, isEquals } from '@blockera/utils';
 import {
 	controlInnerClassNames,
 	controlClassNames,
@@ -61,6 +61,11 @@ const defaultRepeaterItemValue = {
 	attributes: {},
 };
 
+const filteredDefaultRepeaterItemValue = applyFilters(
+	'blockera.breakpoints.defaultRepeaterItemValue',
+	defaultRepeaterItemValue
+);
+
 const BreakpointsSettings: ComponentType<BreakpointSettingsComponentProps> =
 	memo(
 		({
@@ -68,8 +73,23 @@ const BreakpointsSettings: ComponentType<BreakpointSettingsComponentProps> =
 			breakpoints,
 			defaultValue,
 		}: BreakpointSettingsComponentProps): MixedElement => {
-			breakpoints = useMemo(() => {
-				return Object.fromEntries(
+			const customBreakpointIdRef = useRef(
+				Object.keys(breakpoints).reduce((maxId, key) => {
+					const match = /^custom-(\d+)$/.exec(key);
+
+					if (!match) {
+						return maxId;
+					}
+
+					return Math.max(maxId, parseInt(match[1], 10));
+				}, 0)
+			);
+			const stableContextRef = useRef(null);
+
+			const stableMergedRef = useRef(null);
+
+			const mergedBreakpoints = useMemo(() => {
+				const next = Object.fromEntries(
 					Object.entries(breakpoints).map(([key, value]) => [
 						key,
 						mergeObject(defaultRepeaterItemValue, {
@@ -79,18 +99,87 @@ const BreakpointsSettings: ComponentType<BreakpointSettingsComponentProps> =
 						}),
 					])
 				);
-				// eslint-disable-next-line react-hooks/exhaustive-deps
+				const previous = stableMergedRef.current;
+
+				if (previous && isEquals(previous, next)) {
+					return previous;
+				}
+
+				stableMergedRef.current = next;
+
+				return next;
 			}, [breakpoints]);
+
+			const controlContextValue = useMemo(() => {
+				const nextValue = applyFilters(
+					'blockera.breakpoints.value',
+					mergedBreakpoints
+				);
+				const previous = stableContextRef.current;
+
+				if (
+					previous &&
+					isEquals(previous.value, nextValue)
+				) {
+					return previous;
+				}
+
+				const next = {
+					name: 'canvas-editor-breakpoints',
+					value: nextValue,
+					// Keep the repeater store as the editing source of truth.
+					// Parent onChange echoes would otherwise re-sync and remount rows.
+					skipSyncValue: true,
+				};
+
+				stableContextRef.current = next;
+
+				return next;
+			}, [mergedBreakpoints]);
+
+			const valueCleanup = useCallback((value) => {
+				return Object.fromEntries(
+					Object.entries(value).map(([key, item]) => {
+						const cleanRepeaterItem = cleanupRepeaterItem(item);
+
+						if (!item.isDefault) {
+							return [
+								key,
+								{
+									...cleanRepeaterItem,
+									deletable: true,
+								},
+							];
+						}
+
+						return [
+							key,
+							{
+								...cleanRepeaterItem,
+								deletable: false,
+							},
+						];
+					})
+				);
+			}, []);
+
+			const itemIdGenerator = useCallback((): string => {
+				customBreakpointIdRef.current += 1;
+
+				return `custom-${customBreakpointIdRef.current}`;
+			}, []);
+
+			const popoverTitle = useCallback((itemId, item) => {
+				if (getBaseBreakpoint() === itemId) {
+					return item.label;
+				}
+
+				return __('Breakpoint Settings', 'blockera');
+			}, []);
 
 			return (
 				<ControlContextProvider
-					value={{
-						name: 'canvas-editor-breakpoints',
-						value: applyFilters(
-							'blockera.breakpoints.value',
-							breakpoints
-						),
-					}}
+					value={controlContextValue}
 					storeName={REPEATER_STORE_NAME}
 				>
 					<BaseControl
@@ -100,50 +189,18 @@ const BreakpointsSettings: ComponentType<BreakpointSettingsComponentProps> =
 						<RepeaterControl
 							id="breakpoints"
 							mode={'accordion'}
+							// Prop name is inverted in repeater reducers: false keeps stable
+							// slug keys (desktop, tablet, custom-N) when deleting rows.
 							disableRegenerateId={false}
-							popoverTitle={(itemId, item) => {
-								if (getBaseBreakpoint() === itemId) {
-									return item.label;
-								}
-
-								return __('Breakpoint Settings', 'blockera');
-							}}
-							valueCleanup={(value) => {
-								return Object.fromEntries(
-									Object.entries(value).map(([key, item]) => {
-										const cleanRepeaterItem =
-											cleanupRepeaterItem(item);
-
-										if (!item.isDefault) {
-											return [
-												key,
-												{
-													...cleanRepeaterItem,
-													deletable: true,
-												},
-											];
-										}
-
-										return [
-											key,
-											{
-												...cleanRepeaterItem,
-												deletable: false,
-											},
-										];
-									})
-								);
-							}}
-							itemIdGenerator={(itemsCount) => {
-								return `custom-${itemsCount}`;
-							}}
+							popoverTitle={popoverTitle}
+							valueCleanup={valueCleanup}
+							itemIdGenerator={itemIdGenerator}
 							className={controlInnerClassNames(
 								'breakpoints-repeater'
 							)}
-							defaultRepeaterItemValue={applyFilters(
-								'blockera.breakpoints.defaultRepeaterItemValue',
-								defaultRepeaterItemValue
-							)}
+							defaultRepeaterItemValue={
+								filteredDefaultRepeaterItemValue
+							}
 							repeaterItemHeader={Header}
 							repeaterItemChildren={Fields}
 							onChange={onChange}

--- a/packages/editor/js/editor/header-ui/components/breakpoints/breakpoint-settings/index.js
+++ b/packages/editor/js/editor/header-ui/components/breakpoints/breakpoint-settings/index.js
@@ -117,10 +117,7 @@ const BreakpointsSettings: ComponentType<BreakpointSettingsComponentProps> =
 				);
 				const previous = stableContextRef.current;
 
-				if (
-					previous &&
-					isEquals(previous.value, nextValue)
-				) {
+				if (previous && isEquals(previous.value, nextValue)) {
 					return previous;
 				}
 

--- a/packages/editor/js/editor/header-ui/components/breakpoints/get-breakpoint-preview-size.js
+++ b/packages/editor/js/editor/header-ui/components/breakpoints/get-breakpoint-preview-size.js
@@ -14,6 +14,7 @@ export type BreakpointPreviewSize = {
 	width: string,
 	minWidth: string,
 	maxWidth: string,
+	isMinWidthPreview: boolean,
 };
 
 /**
@@ -47,6 +48,7 @@ export const getBreakpointPreviewSize = (
 			width: max,
 			minWidth: '',
 			maxWidth: max,
+			isMinWidthPreview: false,
 		};
 	}
 
@@ -55,6 +57,7 @@ export const getBreakpointPreviewSize = (
 			width: max,
 			minWidth: '',
 			maxWidth: max,
+			isMinWidthPreview: false,
 		};
 	}
 
@@ -63,6 +66,7 @@ export const getBreakpointPreviewSize = (
 			width: min,
 			minWidth: min,
 			maxWidth: max || min,
+			isMinWidthPreview: true,
 		};
 	}
 
@@ -72,12 +76,9 @@ export const getBreakpointPreviewSize = (
 		width,
 		minWidth: min || '',
 		maxWidth: max || width,
+		isMinWidthPreview: Boolean(min && !max),
 	};
 };
-
-const PREVIEW_WIDTH_VAR = '--blockera-breakpoint-preview-width';
-const PREVIEW_MIN_WIDTH_VAR = '--blockera-breakpoint-preview-min-width';
-const PREVIEW_MAX_WIDTH_VAR = '--blockera-breakpoint-preview-max-width';
 
 /**
  * Apply or clear breakpoint preview sizing on the canvas iframe element.
@@ -99,25 +100,20 @@ export const applyBreakpointPreviewSize = (
 	const previewSize = getBreakpointPreviewSize(breakpointId, breakpoints);
 
 	if (!previewSize) {
-		iframe.style.removeProperty(PREVIEW_WIDTH_VAR);
-		iframe.style.removeProperty(PREVIEW_MIN_WIDTH_VAR);
-		iframe.style.removeProperty(PREVIEW_MAX_WIDTH_VAR);
 		iframe.style.width = '100%';
 		iframe.style.minWidth = '';
 		iframe.style.maxWidth = '';
+		iframe.style.boxSizing = '';
 		return;
 	}
 
-	iframe.style.setProperty(PREVIEW_WIDTH_VAR, previewSize.width);
-	iframe.style.setProperty(
-		PREVIEW_MIN_WIDTH_VAR,
-		previewSize.minWidth || 'auto'
-	);
-	iframe.style.setProperty(
-		PREVIEW_MAX_WIDTH_VAR,
-		previewSize.maxWidth || 'none'
-	);
-	iframe.style.removeProperty('width');
-	iframe.style.removeProperty('min-width');
-	iframe.style.removeProperty('max-width');
+	iframe.style.width = previewSize.width;
+	iframe.style.minWidth = previewSize.minWidth || '';
+	iframe.style.maxWidth = previewSize.maxWidth || '';
+
+	// Gutenberg sets border-box on the canvas iframe. Min-width media queries
+	// need the viewport to match the declared min bound, so only those previews
+	// opt into content-box. Max-width previews keep border-box to preserve
+	// existing editor and visual snapshot layouts.
+	iframe.style.boxSizing = previewSize.isMinWidthPreview ? 'content-box' : '';
 };

--- a/packages/editor/js/editor/header-ui/components/breakpoints/get-breakpoint-preview-size.js
+++ b/packages/editor/js/editor/header-ui/components/breakpoints/get-breakpoint-preview-size.js
@@ -1,0 +1,123 @@
+// @flow
+
+/**
+ * Blockera dependencies
+ */
+import type { BreakpointTypes } from '@blockera/editor/js/extensions/libs/block-card/block-states/types';
+
+/**
+ * Internal dependencies
+ */
+import { resolveMediaSettings } from '../../../../style-engine/resolve-media-settings';
+
+export type BreakpointPreviewSize = {
+	width: string,
+	minWidth: string,
+	maxWidth: string,
+};
+
+/**
+ * Derive iframe preview dimensions that match the style-engine media queries.
+ *
+ * Max-width breakpoints preview at their upper bound; min-width breakpoints
+ * preview at their lower bound so `@media (min-width: …)` rules apply inside
+ * the iframe viewport.
+ *
+ * @param {string} breakpointId Active breakpoint identifier.
+ * @param {Object} breakpoints Configured breakpoints map.
+ * @return {?BreakpointPreviewSize} Preview size or null for the base breakpoint.
+ */
+export const getBreakpointPreviewSize = (
+	breakpointId: string,
+	breakpoints: { [key: string]: BreakpointTypes }
+): ?BreakpointPreviewSize => {
+	const breakpoint = breakpoints[breakpointId];
+
+	if (!breakpoint || breakpoint.base) {
+		return null;
+	}
+
+	const mediaSettings = resolveMediaSettings(breakpoints);
+	const { min = '', max = '' } = mediaSettings[breakpointId] || {};
+	const rawMin = breakpoint.settings?.min || '';
+	const rawMax = breakpoint.settings?.max || '';
+
+	if (rawMin && rawMax) {
+		return {
+			width: max,
+			minWidth: '',
+			maxWidth: max,
+		};
+	}
+
+	if (max && !rawMin) {
+		return {
+			width: max,
+			minWidth: '',
+			maxWidth: max,
+		};
+	}
+
+	if (min && !rawMax) {
+		return {
+			width: min,
+			minWidth: min,
+			maxWidth: max || min,
+		};
+	}
+
+	const width = min || max;
+
+	return {
+		width,
+		minWidth: min || '',
+		maxWidth: max || width,
+	};
+};
+
+const PREVIEW_WIDTH_VAR = '--blockera-breakpoint-preview-width';
+const PREVIEW_MIN_WIDTH_VAR = '--blockera-breakpoint-preview-min-width';
+const PREVIEW_MAX_WIDTH_VAR = '--blockera-breakpoint-preview-max-width';
+
+/**
+ * Apply or clear breakpoint preview sizing on the canvas iframe element.
+ *
+ * @param {?HTMLElement} iframe Canvas iframe element.
+ * @param {string} breakpointId Active breakpoint identifier.
+ * @param {Object} breakpoints Configured breakpoints map.
+ * @return {void}
+ */
+export const applyBreakpointPreviewSize = (
+	iframe: ?HTMLElement,
+	breakpointId: string,
+	breakpoints: { [key: string]: BreakpointTypes }
+): void => {
+	if (!iframe?.style) {
+		return;
+	}
+
+	const previewSize = getBreakpointPreviewSize(breakpointId, breakpoints);
+
+	if (!previewSize) {
+		iframe.style.removeProperty(PREVIEW_WIDTH_VAR);
+		iframe.style.removeProperty(PREVIEW_MIN_WIDTH_VAR);
+		iframe.style.removeProperty(PREVIEW_MAX_WIDTH_VAR);
+		iframe.style.width = '100%';
+		iframe.style.minWidth = '';
+		iframe.style.maxWidth = '';
+		return;
+	}
+
+	iframe.style.setProperty(PREVIEW_WIDTH_VAR, previewSize.width);
+	iframe.style.setProperty(
+		PREVIEW_MIN_WIDTH_VAR,
+		previewSize.minWidth || 'auto'
+	);
+	iframe.style.setProperty(
+		PREVIEW_MAX_WIDTH_VAR,
+		previewSize.maxWidth || 'none'
+	);
+	iframe.style.removeProperty('width');
+	iframe.style.removeProperty('min-width');
+	iframe.style.removeProperty('max-width');
+};

--- a/packages/editor/js/editor/header-ui/components/breakpoints/index.js
+++ b/packages/editor/js/editor/header-ui/components/breakpoints/index.js
@@ -20,6 +20,7 @@ import { isEquals, getIframe, getIframeTag } from '@blockera/utils';
 import PickedBreakpoints from './picked-breakpoints';
 import type { BreakpointsComponentProps } from './types';
 import { isBaseBreakpoint, getBaseBreakpoint } from './helpers';
+import { applyBreakpointPreviewSize } from './get-breakpoint-preview-size';
 import { subscribeToEditorModeChanges } from './editor-mode-subscription';
 import { useStoreSelectors } from '../../../../hooks/use-store-selectors';
 import { useStoreDispatchers } from '../../../../hooks/use-store-dispatchers';
@@ -68,8 +69,10 @@ export const BreakpointsUI = ({
 	className,
 	editorMode,
 }: BreakpointsComponentProps): MixedElement => {
-	const { getDeviceType, getBreakpoints, getBreakpoint, getCanvasSettings } =
-		useSelect((select) => select('blockera/editor'), []);
+	const { getDeviceType, getBreakpoints, getCanvasSettings } = useSelect(
+		(select) => select('blockera/editor'),
+		[]
+	);
 	const {
 		setDeviceType,
 		setCanvasSettings,
@@ -109,16 +112,7 @@ export const BreakpointsUI = ({
 			}
 
 			if (editorWrapper) {
-				// Get breakpoint settings for current device.
-				const {
-					settings: { min, max },
-				} = {
-					settings: {
-						min: '',
-						max: '',
-					},
-					...getBreakpoint(deviceType),
-				};
+				const breakpoints = getBreakpoints();
 
 				// Add base canvas class.
 				if (!editorWrapper.classList.contains('blockera-canvas')) {
@@ -138,9 +132,11 @@ export const BreakpointsUI = ({
 						editorWrapper.parentElement.style.background = '';
 
 						if (iframe) {
-							iframe.style.width = '100%';
-							iframe.style.minWidth = '';
-							iframe.style.maxWidth = '';
+							applyBreakpointPreviewSize(
+								iframe,
+								deviceType,
+								breakpoints
+							);
 							iframe.style.transform = '';
 							iframe.parentElement.style.background = '';
 						}
@@ -154,16 +150,12 @@ export const BreakpointsUI = ({
 					}
 
 					if (iframe) {
-						// Set width constraints based on breakpoint settings.
-						if (min && max) {
-							iframe.style.width = max;
-							iframe.style.minWidth = '';
-							iframe.style.maxWidth = max;
-						} else if (min || max) {
-							iframe.style.width = min || max;
-							iframe.style.minWidth = '';
-							iframe.style.maxWidth = '';
-						}
+						// Match iframe viewport to style-engine media query bounds.
+						applyBreakpointPreviewSize(
+							iframe,
+							deviceType,
+							breakpoints
+						);
 
 						// Scale down non-base breakpoints for better preview.
 						if (deviceType !== getBaseBreakpoint()) {

--- a/packages/editor/js/editor/header-ui/components/breakpoints/style.scss
+++ b/packages/editor/js/editor/header-ui/components/breakpoints/style.scss
@@ -1,4 +1,10 @@
 .editor-visual-editor iframe[name="editor-canvas"].blockera-in-breakpoint {
+	// content-box keeps the declared width as the iframe viewport so min-width
+	// media queries match the same values used by the style-engine.
+	box-sizing: content-box;
 	border-radius: 5px;
 	border: 1px solid #c3c3c3 !important;
+	width: var(--blockera-breakpoint-preview-width, 100%) !important;
+	min-width: var(--blockera-breakpoint-preview-min-width, auto);
+	max-width: var(--blockera-breakpoint-preview-max-width, none) !important;
 }

--- a/packages/editor/js/editor/header-ui/components/breakpoints/style.scss
+++ b/packages/editor/js/editor/header-ui/components/breakpoints/style.scss
@@ -1,10 +1,4 @@
 .editor-visual-editor iframe[name="editor-canvas"].blockera-in-breakpoint {
-	// content-box keeps the declared width as the iframe viewport so min-width
-	// media queries match the same values used by the style-engine.
-	box-sizing: content-box;
 	border-radius: 5px;
 	border: 1px solid #c3c3c3 !important;
-	width: var(--blockera-breakpoint-preview-width, 100%) !important;
-	min-width: var(--blockera-breakpoint-preview-min-width, auto);
-	max-width: var(--blockera-breakpoint-preview-max-width, none) !important;
 }

--- a/packages/editor/js/editor/header-ui/components/breakpoints/test/get-breakpoint-preview-size.spec.js
+++ b/packages/editor/js/editor/header-ui/components/breakpoints/test/get-breakpoint-preview-size.spec.js
@@ -1,0 +1,91 @@
+/**
+ * Internal dependencies
+ */
+import defaultBreakpoints from '../../../../../extensions/libs/block-card/block-states/default-breakpoints';
+import {
+	getBreakpointPreviewSize,
+	applyBreakpointPreviewSize,
+} from '../get-breakpoint-preview-size';
+
+describe('getBreakpointPreviewSize', () => {
+	const breakpoints = defaultBreakpoints();
+
+	it('returns null for the base breakpoint', () => {
+		expect(getBreakpointPreviewSize('desktop', breakpoints)).toBeNull();
+	});
+
+	it('previews max-width breakpoints at their max bound', () => {
+		expect(getBreakpointPreviewSize('tablet', breakpoints)).toEqual({
+			width: '991px',
+			minWidth: '',
+			maxWidth: '991px',
+		});
+	});
+
+	it('previews min-width breakpoints at their min bound', () => {
+		const largeBreakpoints = {
+			...breakpoints,
+			'l-desktop': {
+				...breakpoints['l-desktop'],
+				status: true,
+			},
+		};
+
+		expect(getBreakpointPreviewSize('l-desktop', largeBreakpoints)).toEqual(
+			{
+				width: '1280px',
+				minWidth: '1280px',
+				maxWidth: '1439px',
+			}
+		);
+	});
+
+	it('locks the largest min-width breakpoint to its min bound', () => {
+		const largeBreakpoints = {
+			...breakpoints,
+			'2xl-desktop': {
+				...breakpoints['2xl-desktop'],
+				status: true,
+			},
+		};
+
+		expect(
+			getBreakpointPreviewSize('2xl-desktop', largeBreakpoints)
+		).toEqual({
+			width: '1920px',
+			minWidth: '1920px',
+			maxWidth: '1920px',
+		});
+	});
+});
+
+describe('applyBreakpointPreviewSize', () => {
+	it('sets CSS variables for non-base breakpoints', () => {
+		const iframe = document.createElement('iframe');
+		const breakpoints = defaultBreakpoints();
+
+		applyBreakpointPreviewSize(iframe, 'tablet', breakpoints);
+
+		expect(
+			iframe.style.getPropertyValue('--blockera-breakpoint-preview-width')
+		).toBe('991px');
+		expect(
+			iframe.style.getPropertyValue(
+				'--blockera-breakpoint-preview-max-width'
+			)
+		).toBe('991px');
+	});
+
+	it('clears preview sizing for the base breakpoint', () => {
+		const iframe = document.createElement('iframe');
+		const breakpoints = defaultBreakpoints();
+
+		applyBreakpointPreviewSize(iframe, 'tablet', breakpoints);
+		applyBreakpointPreviewSize(iframe, 'desktop', breakpoints);
+
+		expect(
+			iframe.style.getPropertyValue('--blockera-breakpoint-preview-width')
+		).toBe('');
+		expect(iframe.style.width).toBe('100%');
+	});
+});

--- a/packages/editor/js/editor/header-ui/components/breakpoints/test/get-breakpoint-preview-size.spec.js
+++ b/packages/editor/js/editor/header-ui/components/breakpoints/test/get-breakpoint-preview-size.spec.js
@@ -19,6 +19,7 @@ describe('getBreakpointPreviewSize', () => {
 			width: '991px',
 			minWidth: '',
 			maxWidth: '991px',
+			isMinWidthPreview: false,
 		});
 	});
 
@@ -36,6 +37,7 @@ describe('getBreakpointPreviewSize', () => {
 				width: '1280px',
 				minWidth: '1280px',
 				maxWidth: '1439px',
+				isMinWidthPreview: true,
 			}
 		);
 	});
@@ -55,25 +57,37 @@ describe('getBreakpointPreviewSize', () => {
 			width: '1920px',
 			minWidth: '1920px',
 			maxWidth: '1920px',
+			isMinWidthPreview: true,
 		});
 	});
 });
 
 describe('applyBreakpointPreviewSize', () => {
-	it('sets CSS variables for non-base breakpoints', () => {
+	it('sets inline width for max-width breakpoints without content-box', () => {
 		const iframe = document.createElement('iframe');
 		const breakpoints = defaultBreakpoints();
 
 		applyBreakpointPreviewSize(iframe, 'tablet', breakpoints);
 
-		expect(
-			iframe.style.getPropertyValue('--blockera-breakpoint-preview-width')
-		).toBe('991px');
-		expect(
-			iframe.style.getPropertyValue(
-				'--blockera-breakpoint-preview-max-width'
-			)
-		).toBe('991px');
+		expect(iframe.style.width).toBe('991px');
+		expect(iframe.style.maxWidth).toBe('991px');
+		expect(iframe.style.boxSizing).toBe('');
+	});
+
+	it('uses content-box for min-width breakpoints', () => {
+		const iframe = document.createElement('iframe');
+		const breakpoints = {
+			...defaultBreakpoints(),
+			'l-desktop': {
+				...defaultBreakpoints()['l-desktop'],
+				status: true,
+			},
+		};
+
+		applyBreakpointPreviewSize(iframe, 'l-desktop', breakpoints);
+
+		expect(iframe.style.width).toBe('1280px');
+		expect(iframe.style.boxSizing).toBe('content-box');
 	});
 
 	it('clears preview sizing for the base breakpoint', () => {
@@ -83,9 +97,7 @@ describe('applyBreakpointPreviewSize', () => {
 		applyBreakpointPreviewSize(iframe, 'tablet', breakpoints);
 		applyBreakpointPreviewSize(iframe, 'desktop', breakpoints);
 
-		expect(
-			iframe.style.getPropertyValue('--blockera-breakpoint-preview-width')
-		).toBe('');
 		expect(iframe.style.width).toBe('100%');
+		expect(iframe.style.boxSizing).toBe('');
 	});
 });

--- a/packages/editor/js/style-engine/hooks/use-media.js
+++ b/packages/editor/js/style-engine/hooks/use-media.js
@@ -10,96 +10,13 @@ import { select } from '@wordpress/data';
  */
 import type { BreakpointTypes } from '@blockera/editor/js/extensions/libs/block-card/block-states/types';
 
-import { STORE_NAME } from '../../store/constants';
-
-type MediaSettings = {
-	min: string,
-	max: string,
-};
-
-const isValidPx = (value: string): boolean =>
-	!!value && !value.includes('func') && !Number.isNaN(parseInt(value, 10));
-
-const parsePx = (value: string): number => parseInt(value, 10) || 0;
-
-const toPx = (value: number): string => `${value}px`;
-
 /**
- * Resolve min/max media settings for all non-base breakpoints.
- *
- * Explicit min/max pairs are kept as-is. Missing bounds are inferred from
- * neighboring breakpoints so each range is as specific as possible.
- *
- * @param {Object} breakpoints The configured breakpoints.
- * @return {Object} Resolved min/max settings keyed by breakpoint type.
+ * Internal dependencies
  */
-const resolveMediaSettings = (breakpoints: {
-	[key: string]: BreakpointTypes,
-}): { [key: string]: MediaSettings } => {
-	const resolved: { [key: string]: MediaSettings } = {};
-	const items = Object.values(breakpoints).filter(
-		({ type, base }: BreakpointTypes): boolean => !!type && !base
-	);
+import { STORE_NAME } from '../../store/constants';
+import { resolveMediaSettings } from '../resolve-media-settings';
 
-	items.forEach(({ type, settings }: BreakpointTypes): void => {
-		const { min, max } = settings;
-
-		if (min && max) {
-			resolved[type] = { min, max };
-		}
-	});
-
-	const maxOnly = items
-		.filter(
-			({ type, settings }: BreakpointTypes): boolean =>
-				!resolved[type] && isValidPx(settings.max) && !settings.min
-		)
-		.sort(
-			(a: BreakpointTypes, b: BreakpointTypes): number =>
-				parsePx(b.settings.max) - parsePx(a.settings.max)
-		);
-
-	maxOnly.forEach((item: BreakpointTypes, index: number): void => {
-		const next = maxOnly[index + 1];
-		const min =
-			next && isValidPx(next.settings.max)
-				? toPx(parsePx(next.settings.max) + 1)
-				: toPx(0);
-
-		resolved[item.type] = { min, max: item.settings.max };
-	});
-
-	const minOnly = items
-		.filter(
-			({ type, settings }: BreakpointTypes): boolean =>
-				!resolved[type] && isValidPx(settings.min) && !settings.max
-		)
-		.sort(
-			(a: BreakpointTypes, b: BreakpointTypes): number =>
-				parsePx(a.settings.min) - parsePx(b.settings.min)
-		);
-
-	minOnly.forEach((item: BreakpointTypes, index: number): void => {
-		const next = minOnly[index + 1];
-		const max =
-			next && isValidPx(next.settings.min)
-				? toPx(parsePx(next.settings.min) - 1)
-				: '';
-
-		resolved[item.type] = { min: item.settings.min, max };
-	});
-
-	items.forEach(({ type, settings }: BreakpointTypes): void => {
-		if (!resolved[type] && (settings.min || settings.max)) {
-			resolved[type] = {
-				min: settings.min || '',
-				max: settings.max || '',
-			};
-		}
-	});
-
-	return resolved;
-};
+export { resolveMediaSettings } from '../resolve-media-settings';
 
 export const useMedia = (): { [key: string]: string } => {
 	const medias: { [key: string]: string } = {};

--- a/packages/editor/js/style-engine/resolve-media-settings.js
+++ b/packages/editor/js/style-engine/resolve-media-settings.js
@@ -1,0 +1,95 @@
+// @flow
+
+/**
+ * Blockera dependencies
+ */
+import type { BreakpointTypes } from '@blockera/editor/js/extensions/libs/block-card/block-states/types';
+
+type MediaSettings = {
+	min: string,
+	max: string,
+};
+
+export const isValidPx = (value: string): boolean =>
+	!!value && !value.includes('func') && !Number.isNaN(parseInt(value, 10));
+
+export const parsePx = (value: string): number => parseInt(value, 10) || 0;
+
+export const toPx = (value: number): string => `${value}px`;
+
+/**
+ * Resolve min/max media settings for all non-base breakpoints.
+ *
+ * Explicit min/max pairs are kept as-is. Missing bounds are inferred from
+ * neighboring breakpoints so each range is as specific as possible.
+ *
+ * @param {Object} breakpoints The configured breakpoints.
+ * @return {Object} Resolved min/max settings keyed by breakpoint type.
+ */
+export const resolveMediaSettings = (breakpoints: {
+	[key: string]: BreakpointTypes,
+}): { [key: string]: MediaSettings } => {
+	const resolved: { [key: string]: MediaSettings } = {};
+	const items = Object.values(breakpoints).filter(
+		({ type, base }: BreakpointTypes): boolean => !!type && !base
+	);
+
+	items.forEach(({ type, settings }: BreakpointTypes): void => {
+		const { min, max } = settings;
+
+		if (min && max) {
+			resolved[type] = { min, max };
+		}
+	});
+
+	const maxOnly = items
+		.filter(
+			({ type, settings }: BreakpointTypes): boolean =>
+				!resolved[type] && isValidPx(settings.max) && !settings.min
+		)
+		.sort(
+			(a: BreakpointTypes, b: BreakpointTypes): number =>
+				parsePx(b.settings.max) - parsePx(a.settings.max)
+		);
+
+	maxOnly.forEach((item: BreakpointTypes, index: number): void => {
+		const next = maxOnly[index + 1];
+		const min =
+			next && isValidPx(next.settings.max)
+				? toPx(parsePx(next.settings.max) + 1)
+				: toPx(0);
+
+		resolved[item.type] = { min, max: item.settings.max };
+	});
+
+	const minOnly = items
+		.filter(
+			({ type, settings }: BreakpointTypes): boolean =>
+				!resolved[type] && isValidPx(settings.min) && !settings.max
+		)
+		.sort(
+			(a: BreakpointTypes, b: BreakpointTypes): number =>
+				parsePx(a.settings.min) - parsePx(b.settings.min)
+		);
+
+	minOnly.forEach((item: BreakpointTypes, index: number): void => {
+		const next = minOnly[index + 1];
+		const max =
+			next && isValidPx(next.settings.min)
+				? toPx(parsePx(next.settings.min) - 1)
+				: '';
+
+		resolved[item.type] = { min: item.settings.min, max };
+	});
+
+	items.forEach(({ type, settings }: BreakpointTypes): void => {
+		if (!resolved[type] && (settings.min || settings.max)) {
+			resolved[type] = {
+				min: settings.min || '',
+				max: settings.max || '',
+			};
+		}
+	});
+
+	return resolved;
+};


### PR DESCRIPTION
- [x] Box model mismatch — Gutenberg sets box-sizing: border-box on the canvas iframe. The .blockera-in-breakpoint border ate 2px from the viewport, so @media (min-width: 1280px) did not match when the iframe was sized to 1280px.
- [x] Raw vs resolved breakpoint bounds — iframe width used raw min/max from breakpoint settings, while MediaQuery uses resolveMediaSettings() (inferred ranges from neighboring breakpoints).