### PR TITLE
fix(header-ui): show delete button on newly added breakpoints

### DIFF
--- a/packages/editor/js/editor/header-ui/components/breakpoints/breakpoint-settings/index.js
+++ b/packages/editor/js/editor/header-ui/components/breakpoints/breakpoint-settings/index.js
@@ -66,6 +66,22 @@ const filteredDefaultRepeaterItemValue = applyFilters(
 	defaultRepeaterItemValue
 );
 
+const newBreakpointRepeaterItemDefaults = {
+	...filteredDefaultRepeaterItemValue,
+	deletable: true,
+	native: false,
+	isDefault: false,
+	status: true,
+};
+
+const isBreakpointDeletable = (item: Object, breakpointId: string): boolean => {
+	if (item?.isDefault || breakpointId === getBaseBreakpoint()) {
+		return false;
+	}
+
+	return true;
+};
+
 const BreakpointsSettings: ComponentType<BreakpointSettingsComponentProps> =
 	memo(
 		({
@@ -96,6 +112,7 @@ const BreakpointsSettings: ComponentType<BreakpointSettingsComponentProps> =
 							...value,
 							// $FlowFixMe
 							native: value?.native || false,
+							deletable: isBreakpointDeletable(value, key),
 						}),
 					])
 				);
@@ -196,7 +213,7 @@ const BreakpointsSettings: ComponentType<BreakpointSettingsComponentProps> =
 								'breakpoints-repeater'
 							)}
 							defaultRepeaterItemValue={
-								filteredDefaultRepeaterItemValue
+								newBreakpointRepeaterItemDefaults
 							}
 							repeaterItemHeader={Header}
 							repeaterItemChildren={Fields}


### PR DESCRIPTION
- [x] - Add newBreakpointRepeaterItemDefaults with deletable true for custom rows
- [x] - Resolve deletable flag when merging breakpoints from saved data
- [x] - Keep default and base breakpoints non-deletable