### PR TITLE
ci: pack Cypress E2E matrix shards by registered it() count

### DIFF
--- a/.github/workflows/cypress-e2e-tests.yml
+++ b/.github/workflows/cypress-e2e-tests.yml
@@ -14,6 +14,7 @@ env:
     BLOCKERA_GLOBAL_PACKAGES_TOKEN: ${{ secrets.BLOCKERABOT_PAT }}
     BLOCKERA_E2E_SCAN_ROOTS: packages,tests
     BLOCKERA_E2E_GENERAL_CATEGORY: general-1
+    BLOCKERA_E2E_SHARD_SIZE: '100'
 
 jobs:
     pr-workflow-gate:

--- a/.github/workflows/cypress-e2e-tests.yml
+++ b/.github/workflows/cypress-e2e-tests.yml
@@ -14,7 +14,7 @@ env:
     BLOCKERA_GLOBAL_PACKAGES_TOKEN: ${{ secrets.BLOCKERABOT_PAT }}
     BLOCKERA_E2E_SCAN_ROOTS: packages,tests
     BLOCKERA_E2E_GENERAL_CATEGORY: general-1
-    BLOCKERA_E2E_SHARD_SIZE: '70'
+    BLOCKERA_E2E_SHARD_SIZE: '50'
 
 jobs:
     pr-workflow-gate:

--- a/.github/workflows/cypress-e2e-tests.yml
+++ b/.github/workflows/cypress-e2e-tests.yml
@@ -14,7 +14,7 @@ env:
     BLOCKERA_GLOBAL_PACKAGES_TOKEN: ${{ secrets.BLOCKERABOT_PAT }}
     BLOCKERA_E2E_SCAN_ROOTS: packages,tests
     BLOCKERA_E2E_GENERAL_CATEGORY: general-1
-    BLOCKERA_E2E_SHARD_SIZE: '50'
+    BLOCKERA_E2E_SHARD_SIZE: '40'
 
 jobs:
     pr-workflow-gate:

--- a/.github/workflows/cypress-e2e-tests.yml
+++ b/.github/workflows/cypress-e2e-tests.yml
@@ -14,7 +14,7 @@ env:
     BLOCKERA_GLOBAL_PACKAGES_TOKEN: ${{ secrets.BLOCKERABOT_PAT }}
     BLOCKERA_E2E_SCAN_ROOTS: packages,tests
     BLOCKERA_E2E_GENERAL_CATEGORY: general-1
-    BLOCKERA_E2E_SHARD_SIZE: '80'
+    BLOCKERA_E2E_SHARD_SIZE: '70'
 
 jobs:
     pr-workflow-gate:

--- a/.github/workflows/cypress-e2e-tests.yml
+++ b/.github/workflows/cypress-e2e-tests.yml
@@ -14,7 +14,7 @@ env:
     BLOCKERA_GLOBAL_PACKAGES_TOKEN: ${{ secrets.BLOCKERABOT_PAT }}
     BLOCKERA_E2E_SCAN_ROOTS: packages,tests
     BLOCKERA_E2E_GENERAL_CATEGORY: general-1
-    BLOCKERA_E2E_SHARD_SIZE: '100'
+    BLOCKERA_E2E_SHARD_SIZE: '80'
 
 jobs:
     pr-workflow-gate:

--- a/tests/performance/fixtures/editor-perf-utils.js
+++ b/tests/performance/fixtures/editor-perf-utils.js
@@ -343,7 +343,7 @@ class EditorPerfUtils {
 
 	/**
 	 * Opens the background layer popover and uploads an image via Media Library
-	 * (mirrors background-image.general-4.e2e.cy.js + media-image.general-4.e2e.cy.js).
+	 * (mirrors background-image.general.e2e.cy.js + media-image.general.e2e.cy.js).
 	 *
 	 * @param {string} [filePath] Absolute path to the upload fixture.
 	 * @param {Object} [options]
@@ -376,7 +376,7 @@ class EditorPerfUtils {
 
 	/**
 	 * Adds a background image layer via Image & Gradient repeater
-	 * (see background-image.general-4.e2e.cy.js).
+	 * (see background-image.general.e2e.cy.js).
 	 *
 	 * @param {string} [filePath] Absolute path to the upload fixture.
 	 */
@@ -513,7 +513,7 @@ class EditorPerfUtils {
 
 	/**
 	 * Waits until the selected block stores an uploaded background image
-	 * (mirrors background-image.general-4.e2e.cy.js assertBlockData).
+	 * (mirrors background-image.general.e2e.cy.js assertBlockData).
 	 */
 	async expectSelectedBlockBackgroundImage() {
 		await this.page.waitForFunction(


### PR DESCRIPTION
## Summary
- Cypress E2E CI now shards each filename category (`compatibility`, `general`, …) into `base-1`…`N` from registered `it()` count (max 100 per job via `BLOCKERA_E2E_SHARD_SIZE`), including `it`s generated by array `.forEach`.
- Specs no longer use manual `-1` / `-2` suffixes; `run.sh` passes an explicit `--spec` list. wp-env still loads `woocommerce.json` for a `woocommerce-2` job.
- Playwright is unchanged; other products keep filename categories until they set `SHARD_SIZE`.

## Test plan
- [x] Confirm `Detecting E2E Test Categories` emits `*-1`, `*-2`, … (not one oversized `compatibility` job).
- [x] Confirm a matrix job’s `--spec` list is a subset of that base category and finishes under the job timeout.
- [x] PR-filtered e2e still only runs matching specs, packed into shards from that subset.
- [x] A category with a dedicated wp-env file (e.g. `woocommerce`) still uses that config when the matrix id is `woocommerce-N`.